### PR TITLE
[SDPA-966] Updated campaign field config for landing page module

### DIFF
--- a/config/install/core.entity_form_display.node.landing_page.default.yml
+++ b/config/install/core.entity_form_display.node.landing_page.default.yml
@@ -295,7 +295,7 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: entity_reference_revisions_autocomplete
+    type: entity_reference_autocomplete
     region: content
   field_landing_page_c_secondary:
     weight: 26
@@ -304,7 +304,7 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: entity_reference_revisions_autocomplete
+    type: entity_reference_autocomplete
     region: content
   field_landing_page_component:
     type: paragraphs

--- a/config/install/core.entity_view_display.node.landing_page.default.yml
+++ b/config/install/core.entity_view_display.node.landing_page.default.yml
@@ -88,7 +88,7 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    type: entity_reference_revisions_entity_view
+    type: entity_reference_entity_id
     region: content
   field_landing_page_c_secondary:
     weight: 6
@@ -97,7 +97,7 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    type: entity_reference_revisions_entity_view
+    type: entity_reference_entity_id
     region: content
   field_landing_page_component:
     weight: 1

--- a/config/install/field.field.node.landing_page.field_landing_page_c_primary.yml
+++ b/config/install/field.field.node.landing_page.field_landing_page_c_primary.yml
@@ -5,8 +5,6 @@ dependencies:
     - block_content.type.campaign
     - field.storage.node.field_landing_page_c_primary
     - node.type.landing_page
-  module:
-    - entity_reference_revisions
 id: node.landing_page.field_landing_page_c_primary
 field_name: field_landing_page_c_primary
 entity_type: node
@@ -26,4 +24,4 @@ settings:
       field: _none
     auto_create: false
     auto_create_bundle: ''
-field_type: entity_reference_revisions
+field_type: entity_reference

--- a/config/install/field.field.node.landing_page.field_landing_page_c_secondary.yml
+++ b/config/install/field.field.node.landing_page.field_landing_page_c_secondary.yml
@@ -5,8 +5,6 @@ dependencies:
     - block_content.type.campaign
     - field.storage.node.field_landing_page_c_secondary
     - node.type.landing_page
-  module:
-    - entity_reference_revisions
 id: node.landing_page.field_landing_page_c_secondary
 field_name: field_landing_page_c_secondary
 entity_type: node
@@ -26,4 +24,4 @@ settings:
       field: _none
     auto_create: false
     auto_create_bundle: ''
-field_type: entity_reference_revisions
+field_type: entity_reference


### PR DESCRIPTION
JIRA:
- https://digital-engagement.atlassian.net/browse/SDPA-966

Changes:
1. Change `entity_reference_revisions_autocomplete` to `entity_reference_autocomplete` in form display
2. Correct type in view mode. Note we only need the `entity_reference_entity_id` instead of `entity_reference_entity_view` since the landing page content type only need to reference the campaign entity_id

**Note**: this PR also have the changes in https://github.com/dpc-sdp/tide_landing_page/pull/23