### PR TITLE
[SDPA-1354] Manual Card Event - incorrect date shown if the date that is selected is in AM 

### DIFF
--- a/config/optional/jsonapi_extras.jsonapi_resource_config.paragraph--card_event.yml
+++ b/config/optional/jsonapi_extras.jsonapi_resource_config.paragraph--card_event.yml
@@ -162,6 +162,13 @@ resourceFields:
     disabled: false
     advancedOptionsIcon: ''
     enhancer_label: ''
+  field_paragraph_date_range:
+    fieldName: field_paragraph_date_range
+    publicName: field_paragraph_date_range
+    enhancer:
+      id: date_time_from_string
+      settings:
+        dateTimeFormat: 'Y-m-d\TH:i:sP'
   field_paragraph_location:
     fieldName: field_paragraph_location
     publicName: field_paragraph_location


### PR DESCRIPTION
JIRA: https://digital-engagement.atlassian.net/browse/SDPA-1354

RELATED PRs:
1. Content PR:  https://github.com/dpc-sdp/content-vic-gov-au/pull/363

**Changes**
1. Add enhancer for field_paragraph_date_range