### PR TITLE
[SDPA-1225] Tide - Summary field in carousal Card event is not ristricted to 200 characters

### DIFF
--- a/config/install/core.entity_form_display.paragraph.card_event.default.yml
+++ b/config/install/core.entity_form_display.paragraph.card_event.default.yml
@@ -16,6 +16,7 @@ dependencies:
     - datetime_range
     - entity_browser
     - link
+    - maxlength
 id: paragraph.card_event.default
 targetEntityType: paragraph
 bundle: card_event
@@ -37,8 +38,7 @@ content:
     region: content
   field_paragraph_location:
     weight: 4
-    settings:
-      default_country: null
+    settings: {  }
     third_party_settings: {  }
     type: address_default
     region: content
@@ -61,9 +61,14 @@ content:
     type: string_textarea
     weight: 5
     settings:
-      placeholder: ''
       rows: 5
-    third_party_settings: {  }
+      placeholder: ''
+    third_party_settings:
+      maxlength:
+        maxlength_js: 200
+        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: false
+        maxlength_js_truncate_html: false
     region: content
   field_paragraph_title:
     weight: 0

--- a/tide_landing_page.install
+++ b/tide_landing_page.install
@@ -384,3 +384,27 @@ function tide_landing_page_update_8008() {
     $field_config->save();
   }
 }
+
+/**
+ * Summary field in carousal Card event is restricted to 200 characters.
+ */
+function tide_landing_page_update_8009() {
+  /** @var \Drupal\Core\Entity\Display\EntityFormDisplayInterface $entity_form_display */
+  $entity_form_display = Drupal::entityTypeManager()
+    ->getStorage('entity_form_display')
+    ->load('paragraph.card_event.default');
+  $field_paragraph_summary = $entity_form_display->getComponent('field_paragraph_summary');
+  if (!isset($field_paragraph_summary['third_party_settings']) || !isset($field_paragraph_summary['third_party_settings']['maxlength']['maxlength_js'])) {
+    $entity_form_display->setComponent('field_paragraph_summary', [
+      'third_party_settings' => [
+        'maxlength' => [
+          'maxlength_js' => 200,
+          'maxlength_js_label' => 'Content limited to @limit characters, remaining: @remaining',
+          'maxlength_js_enforce' => FALSE,
+          'maxlength_js_truncate_html' => FALSE,
+        ],
+      ],
+    ]);
+    $entity_form_display->save();
+  }
+}

--- a/tide_landing_page.install
+++ b/tide_landing_page.install
@@ -395,16 +395,15 @@ function tide_landing_page_update_8009() {
     ->load('paragraph.card_event.default');
   $field_paragraph_summary = $entity_form_display->getComponent('field_paragraph_summary');
   if (!isset($field_paragraph_summary['third_party_settings']) || !isset($field_paragraph_summary['third_party_settings']['maxlength']['maxlength_js'])) {
-    $entity_form_display->setComponent('field_paragraph_summary', [
-      'third_party_settings' => [
-        'maxlength' => [
-          'maxlength_js' => 200,
-          'maxlength_js_label' => 'Content limited to @limit characters, remaining: @remaining',
-          'maxlength_js_enforce' => FALSE,
-          'maxlength_js_truncate_html' => FALSE,
-        ],
+    $field_paragraph_summary['third_party_settings'] = [
+      'maxlength' => [
+        'maxlength_js' => 200,
+        'maxlength_js_label' => 'Content limited to @limit characters, remaining: @remaining',
+        'maxlength_js_enforce' => FALSE,
+        'maxlength_js_truncate_html' => FALSE,
       ],
-    ]);
+    ];
+    $entity_form_display->setComponent('field_paragraph_summary', $field_paragraph_summary);
     $entity_form_display->save();
   }
 }


### PR DESCRIPTION
more details see https://digital-engagement.atlassian.net/projects/SDPA/issues/SDPA-1225

relates to https://github.com/dpc-sdp/tide_landing_page/pull/73  close #73 because of a patch issue.

the update id was 8008(in the first commit in #73 `3d160044cc4ca2f788331c889d8bb2a02b2f837f`) which conflicts with an existing one.  there is no chance to amend the older commit to 8009. even though the latest commit is already 8009(in #73), which still causes a composer issue when updating with content-vic. 
created a new pr to avoid this issue.