### PR TITLE
[SDPA-3231] Fixed timelines missed issue

### DIFF
--- a/config/install/field.field.node.landing_page.field_landing_page_component.yml
+++ b/config/install/field.field.node.landing_page.field_landing_page_component.yml
@@ -20,6 +20,7 @@ dependencies:
     - paragraphs.paragraphs_type.complex_image
     - paragraphs.paragraphs_type.latest_events
     - paragraphs.paragraphs_type.media_gallery
+    - paragraphs.paragraphs_type.timelines
   module:
     - entity_reference_revisions
 id: node.landing_page.field_landing_page_component

--- a/tide_landing_page.install
+++ b/tide_landing_page.install
@@ -501,3 +501,19 @@ function tide_landing_page_update_8013() {
     $entity_form_display->save();
   }
 }
+
+/**
+ * Adds timeline paragraph type to field_landing_page_component.
+ */
+function tide_landing_page_update_8014() {
+  $field = FieldConfig::loadByName('node', 'landing_page', 'field_landing_page_component');
+  if ($field) {
+    $handler_settings = $field->getSetting('handler_settings');
+    if (isset($handler_settings['target_bundles']) && !in_array('timelines', $handler_settings['target_bundles'])) {
+      $handler_settings['target_bundles']['timelines'] = 'timelines';
+      $handler_settings['target_bundles_drag_drop']['timelines']['enabled'] = TRUE;
+      $field->setSetting('handler_settings', $handler_settings);
+      $field->save();
+    }
+  }
+}


### PR DESCRIPTION
Timeline paragraph should be available independently of tide_grant

https://digital-engagement.atlassian.net/browse/SDPA-3231

1. issue
As an editor I can add a timeline component to landing pages

2. Test Scenario

Without the Tide Grant module enabledAs a user with the editor role

3. Expected behaviour

When adding a landing page I can select Timeline from the list of body components

4. Actual behaviour

Timeline is not available

5. Solution direction

Move timeline config into tide_landing_page

Add update hook to install timeline component if not already installed

related PRs:
https://github.com/dpc-sdp/content-vic-gov-au/pull/708
https://github.com/dpc-sdp/tide_core/pull/95
