### PR TITLE
[SDPA-4364] Added update hook to enable landing page for use with scheduled transitions.

### DIFF
--- a/tide_landing_page.install
+++ b/tide_landing_page.install
@@ -69,6 +69,26 @@ function tide_landing_page_install() {
   }
 
   _tide_landing_page_add_fields_search_api();
+
+  // Enable entity type/bundles for use with scheduled transitions.
+  if (\Drupal::moduleHandler()->moduleExists('scheduled_transitions')) {
+    $config_factory = \Drupal::configFactory();
+    $config = $config_factory->getEditable('scheduled_transitions.settings');
+    $bundles = $config->get('bundles');
+    if ($bundles) {
+      foreach ($bundles as $bundle) {
+        $enabled_bundles[] = $bundle['bundle'];
+      }
+      if (!in_array('landing_page', $enabled_bundles)) {
+        $bundles[] = ['entity_type' => 'node', 'bundle' => 'landing_page'];
+        $config->set('bundles', $bundles)->save();
+      }
+    }
+    else {
+      $bundles[] = ['entity_type' => 'node', 'bundle' => 'landing_page'];
+      $config->set('bundles', $bundles)->save();
+    }
+  }
 }
 
 /**

--- a/tide_landing_page.install
+++ b/tide_landing_page.install
@@ -776,3 +776,27 @@ function tide_landing_page_update_8018() {
     $field->save();
   }
 }
+
+/**
+ * Enable entity type/bundles for use with scheduled transitions.
+ */
+function tide_landing_page_update_8019() {
+  if (\Drupal::moduleHandler()->moduleExists('scheduled_transitions')) {
+    $config_factory = \Drupal::configFactory();
+    $config = $config_factory->getEditable('scheduled_transitions.settings');
+    $bundles = $config->get('bundles');
+    if ($bundles) {
+      foreach ($bundles as $bundle) {
+        $enabled_bundles[] = $bundle['bundle'];
+      }
+      if (!in_array('landing_page', $enabled_bundles)) {
+        $bundles[] = ['entity_type' => 'node', 'bundle' => 'landing_page'];
+        $config->set('bundles', $bundles)->save();
+      }
+    }
+    else {
+      $bundles[] = ['entity_type' => 'node', 'bundle' => 'landing_page'];
+      $config->set('bundles', $bundles)->save();
+    }
+  }
+}


### PR DESCRIPTION
### Jira
Parent ticket - https://digital-engagement.atlassian.net/browse/SDPA-4313
Sub task - https://digital-engagement.atlassian.net/browse/SDPA-4364
### Changes
1. Added update hook to enable schedule transitions for tide_landing_page.