### PR TITLE
[SDPA-4696] apply the states api to all node form

### DIFF
--- a/tide_landing_page.module
+++ b/tide_landing_page.module
@@ -111,18 +111,18 @@ function tide_landing_page_form_node_form_alter(&$form, FormStateInterface $form
         }
       }
     }
-    // Add conditional field for show table of content.
-    if (isset($form['field_node_display_headings'])) {
-      $form['field_node_display_headings']['#states'] = [
-        'visible' => [
-          ':input[name="field_show_table_of_content[value]"]' => [
-            'checked' => TRUE,
-          ],
+  }
+  // Add conditional field for show table of content.
+  if (isset($form['field_node_display_headings']) && isset($form['field_show_table_of_content'])) {
+    $form['field_node_display_headings']['#states'] = [
+      'visible' => [
+        ':input[name="field_show_table_of_content[value]"]' => [
+          'checked' => TRUE,
         ],
-      ];
-      if (!isset($form['field_node_display_headings']['widget']['#default_value'])) {
-        $form['field_node_display_headings']['widget']['#default_value'] = 'showH2';
-      }
+      ],
+    ];
+    if (!isset($form['field_node_display_headings']['widget']['#default_value'])) {
+      $form['field_node_display_headings']['widget']['#default_value'] = 'showH2';
     }
   }
 }

--- a/tide_landing_page.module
+++ b/tide_landing_page.module
@@ -121,7 +121,7 @@ function tide_landing_page_form_node_form_alter(&$form, FormStateInterface $form
         ],
       ],
     ];
-    if (!isset($form['field_node_display_headings']['widget']['#default_value'])) {
+    if (!isset($form['field_node_display_headings']['widget']['#default_value']) || empty($form['field_node_display_headings']['widget']['#default_value'])) {
       $form['field_node_display_headings']['widget']['#default_value'] = 'showH2';
     }
   }


### PR DESCRIPTION
### jira
https://digital-engagement.atlassian.net/browse/SDPA-4696

### changes
if the field `field_node_display_headings` and `field_show_table_of_content` both applied to a node form, the `#states` should also apply to.
move the logic out of `node_landing_page_form`