### PR TITLE
Install card collection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "dpc-sdp/tide_api:^1.2.6": "Allows to use Drupal in headless mode",
         "dpc-sdp/tide_webform:^1.2.4": "Allows to use questionnaires",
         "dpc-sdp/tide_news:^1.1.5": "News content type and related configuration for Tide Drupal 8 distribution",
-        "dpc-sdp/tide_automated_listing:dev-feature/TVD-200-Install-card-collection": "Allows to use tide automated listing"
+        "dpc-sdp/tide_automated_listing:1.0.0-beta": "Allows to use tide automated listing"
     },
     "repositories": {
         "drupal": {

--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,18 @@
     "suggest": {
         "dpc-sdp/tide_api:^1.2.6": "Allows to use Drupal in headless mode",
         "dpc-sdp/tide_webform:^1.2.4": "Allows to use questionnaires",
-        "dpc-sdp/tide_news:^1.1.5": "News content type and related configuration for Tide Drupal 8 distribution"
+        "dpc-sdp/tide_news:^1.1.5": "News content type and related configuration for Tide Drupal 8 distribution",
+        "dpc-sdp/tide_automated_listing:dev-feature/TVD-200-Install-card-collection": "Allows to use tide automated listing"
     },
     "repositories": {
         "drupal": {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
+        },
+        "dpc-sdp/tide_automated_listing": {
+            "type": "vcs",
+            "no-api": true,
+            "url": "https://github.com/dpc-sdp/tide_automated_listing.git"
         }
     }
 }

--- a/config/install/core.entity_form_display.paragraph.navigation_card.default.yml
+++ b/config/install/core.entity_form_display.paragraph.navigation_card.default.yml
@@ -1,0 +1,74 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - entity_browser.browser.tide_image_browser
+    - field.field.paragraph.navigation_card.field_nav_card_display_style
+    - field.field.paragraph.navigation_card.field_customise
+    - field.field.paragraph.navigation_card.field_paragraph_link
+    - field.field.paragraph.navigation_card.field_paragraph_media
+    - field.field.paragraph.navigation_card.field_paragraph_summary
+    - field.field.paragraph.navigation_card.field_paragraph_title
+    - paragraphs.paragraphs_type.navigation_card
+  module:
+    - entity_browser
+    - link
+id: paragraph.navigation_card.default
+targetEntityType: paragraph
+bundle: navigation_card
+mode: default
+content:
+  field_nav_card_display_style:
+    weight: 3
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
+    region: content
+  field_customise:
+    weight: 5
+    settings:
+      display_label: false
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
+  field_paragraph_link:
+    weight: 0
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
+  field_paragraph_media:
+    weight: 4
+    settings:
+      entity_browser: tide_image_browser
+      field_widget_display: label
+      field_widget_edit: true
+      field_widget_remove: true
+      selection_mode: selection_append
+      field_widget_replace: false
+      open: false
+      field_widget_display_settings: {  }
+    third_party_settings: {  }
+    type: entity_browser_entity_reference
+    region: content
+  field_paragraph_summary:
+    weight: 2
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textarea
+    region: content
+  field_paragraph_title:
+    weight: 1
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+hidden:
+  created: true
+  status: true

--- a/config/install/core.entity_form_display.paragraph.promotion_card.default.yml
+++ b/config/install/core.entity_form_display.paragraph.promotion_card.default.yml
@@ -1,0 +1,81 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - entity_browser.browser.tide_image_browser
+    - field.field.paragraph.promotion_card.field_promo_card_display_style
+    - field.field.paragraph.promotion_card.field_customise
+    - field.field.paragraph.promotion_card.field_paragraph_link
+    - field.field.paragraph.promotion_card.field_paragraph_media
+    - field.field.paragraph.promotion_card.field_paragraph_summary
+    - field.field.paragraph.promotion_card.field_paragraph_title
+    - paragraphs.paragraphs_type.promotion_card
+  module:
+    - entity_browser
+    - link
+    - maxlength
+id: paragraph.promotion_card.default
+targetEntityType: paragraph
+bundle: promotion_card
+mode: default
+content:
+  field_promo_card_display_style:
+    weight: 3
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
+    region: content
+  field_customise:
+    weight: 5
+    settings:
+      display_label: false
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
+  field_paragraph_link:
+    weight: 0
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
+  field_paragraph_media:
+    weight: 4
+    settings:
+      entity_browser: tide_image_browser
+      field_widget_display: rendered_entity
+      field_widget_display_settings:
+        view_mode: media_browser_preview
+      field_widget_edit: true
+      field_widget_remove: true
+      open: true
+      selection_mode: selection_append
+      field_widget_replace: false
+    third_party_settings: {  }
+    type: entity_browser_entity_reference
+    region: content
+  field_paragraph_summary:
+    weight: 2
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings:
+      maxlength:
+        maxlength_js: 200
+        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: false
+        maxlength_js_truncate_html: false
+    type: string_textarea
+    region: content
+  field_paragraph_title:
+    weight: 1
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+hidden:
+  created: true
+  status: true

--- a/config/install/core.entity_view_display.paragraph.navigation_card.default.yml
+++ b/config/install/core.entity_view_display.paragraph.navigation_card.default.yml
@@ -1,0 +1,73 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.navigation_card.field_nav_card_display_style
+    - field.field.paragraph.navigation_card.field_customise
+    - field.field.paragraph.navigation_card.field_paragraph_link
+    - field.field.paragraph.navigation_card.field_paragraph_media
+    - field.field.paragraph.navigation_card.field_paragraph_summary
+    - field.field.paragraph.navigation_card.field_paragraph_title
+    - paragraphs.paragraphs_type.navigation_card
+  module:
+    - link
+    - options
+id: paragraph.navigation_card.default
+targetEntityType: paragraph
+bundle: navigation_card
+mode: default
+content:
+  field_nav_card_display_style:
+    weight: 0
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: list_default
+    region: content
+  field_customise:
+    weight: 1
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    type: boolean
+    region: content
+  field_paragraph_link:
+    weight: 3
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+  field_paragraph_media:
+    weight: 2
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_paragraph_summary:
+    weight: 4
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+  field_paragraph_title:
+    weight: 5
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/install/core.entity_view_display.paragraph.promotion_card.default.yml
+++ b/config/install/core.entity_view_display.paragraph.promotion_card.default.yml
@@ -1,0 +1,73 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.promotion_card.field_promo_card_display_style
+    - field.field.paragraph.promotion_card.field_customise
+    - field.field.paragraph.promotion_card.field_paragraph_link
+    - field.field.paragraph.promotion_card.field_paragraph_media
+    - field.field.paragraph.promotion_card.field_paragraph_summary
+    - field.field.paragraph.promotion_card.field_paragraph_title
+    - paragraphs.paragraphs_type.promotion_card
+  module:
+    - link
+    - options
+id: paragraph.promotion_card.default
+targetEntityType: paragraph
+bundle: promotion_card
+mode: default
+content:
+  field_promo_card_display_style:
+    weight: 3
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: list_default
+    region: content
+  field_customise:
+    weight: 4
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    type: boolean
+    region: content
+  field_paragraph_link:
+    weight: 0
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+  field_paragraph_media:
+    weight: 5
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_paragraph_summary:
+    weight: 2
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+  field_paragraph_title:
+    weight: 1
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/install/field.field.node.landing_page.field_landing_page_component.yml
+++ b/config/install/field.field.node.landing_page.field_landing_page_component.yml
@@ -21,6 +21,7 @@ dependencies:
     - paragraphs.paragraphs_type.form_embed_openforms
     - paragraphs.paragraphs_type.latest_events
     - paragraphs.paragraphs_type.media_gallery
+    - paragraphs.paragraphs_type.navigation_card
     - paragraphs.paragraphs_type.promotion_card
     - paragraphs.paragraphs_type.timelines
   module:
@@ -60,6 +61,7 @@ settings:
       card_carousel: card_carousel
       timelines: timelines
       news_listing: news_listing
+      navigation_card: navigation_card
       promotion_card: promotion_card
     target_bundles_drag_drop:
       banner:
@@ -128,9 +130,12 @@ settings:
       news_listing:
         enabled: true
         weight: 25
-      media_gallery:
+      navigation_card:
         enabled: true
         weight: 26
+      media_gallery:
+        enabled: true
+        weight: 27
       card_event_auto:
         enabled: true
         weight: 28

--- a/config/install/field.field.node.landing_page.field_landing_page_component.yml
+++ b/config/install/field.field.node.landing_page.field_landing_page_component.yml
@@ -21,6 +21,7 @@ dependencies:
     - paragraphs.paragraphs_type.form_embed_openforms
     - paragraphs.paragraphs_type.latest_events
     - paragraphs.paragraphs_type.media_gallery
+    - paragraphs.paragraphs_type.promotion_card
     - paragraphs.paragraphs_type.timelines
   module:
     - entity_reference_revisions
@@ -59,6 +60,7 @@ settings:
       card_carousel: card_carousel
       timelines: timelines
       news_listing: news_listing
+      promotion_card: promotion_card
     target_bundles_drag_drop:
       banner:
         weight: -33
@@ -147,6 +149,9 @@ settings:
       phone:
         weight: 38
         enabled: false
+      promotion_card:
+        enabled: true
+        weight: 39
       social_link:
         weight: 40
         enabled: false

--- a/config/install/field.field.paragraph.navigation_card.field_customise.yml
+++ b/config/install/field.field.paragraph.navigation_card.field_customise.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_customise
+    - paragraphs.paragraphs_type.navigation_card
+id: paragraph.navigation_card.field_customise
+field_name: field_customise
+entity_type: paragraph
+bundle: navigation_card
+label: Customise
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'Show topic and category'
+  off_label: 'Off'
+field_type: boolean

--- a/config/install/field.field.paragraph.navigation_card.field_nav_card_display_style.yml
+++ b/config/install/field.field.paragraph.navigation_card.field_nav_card_display_style.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_nav_card_display_style
+    - paragraphs.paragraphs_type.navigation_card
+  module:
+    - options
+id: paragraph.navigation_card.field_nav_card_display_style
+field_name: field_nav_card_display_style
+entity_type: paragraph
+bundle: navigation_card
+label: 'Card Display Style'
+description: ''
+required: true
+translatable: true
+default_value:
+  -
+    value: standard
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/install/field.field.paragraph.navigation_card.field_paragraph_link.yml
+++ b/config/install/field.field.paragraph.navigation_card.field_paragraph_link.yml
@@ -3,7 +3,7 @@ status: true
 dependencies:
   config:
     - field.storage.paragraph.field_paragraph_link
-    - paragraphs.paragraphs_type.promotion_card
+    - paragraphs.paragraphs_type.navigation_card
   module:
     - link
     - link_field_autocomplete_filter
@@ -27,10 +27,10 @@ third_party_settings:
       translated_page: 0
       vada_profile: 0
       vdrp_profile: 0
-id: paragraph.promotion_card.field_paragraph_link
+id: paragraph.navigation_card.field_paragraph_link
 field_name: field_paragraph_link
 entity_type: paragraph
-bundle: promotion_card
+bundle: navigation_card
 label: Link
 description: ''
 required: true

--- a/config/install/field.field.paragraph.navigation_card.field_paragraph_media.yml
+++ b/config/install/field.field.paragraph.navigation_card.field_paragraph_media.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_paragraph_media
+    - media.type.image
+    - paragraphs.paragraphs_type.navigation_card
+id: paragraph.navigation_card.field_paragraph_media
+field_name: field_paragraph_media
+entity_type: paragraph
+bundle: navigation_card
+label: 'Image'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/install/field.field.paragraph.navigation_card.field_paragraph_summary.yml
+++ b/config/install/field.field.paragraph.navigation_card.field_paragraph_summary.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_paragraph_summary
+    - paragraphs.paragraphs_type.navigation_card
+id: paragraph.navigation_card.field_paragraph_summary
+field_name: field_paragraph_summary
+entity_type: paragraph
+bundle: navigation_card
+label: Summary
+description: 'This optional summary will be shown underneath the title.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/install/field.field.paragraph.navigation_card.field_paragraph_title.yml
+++ b/config/install/field.field.paragraph.navigation_card.field_paragraph_title.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_paragraph_title
+    - paragraphs.paragraphs_type.navigation_card
+id: paragraph.navigation_card.field_paragraph_title
+field_name: field_paragraph_title
+entity_type: paragraph
+bundle: navigation_card
+label: Title
+description: 'This title will be displayed as the primary call-to-action on the card.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/install/field.field.paragraph.promotion_card.field_customise.yml
+++ b/config/install/field.field.paragraph.promotion_card.field_customise.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_customise
+    - paragraphs.paragraphs_type.promotion_card
+id: paragraph.promotion_card.field_customise
+field_name: field_customise
+entity_type: paragraph
+bundle: promotion_card
+label: Customise
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'Show topic and category'
+  off_label: 'Off'
+field_type: boolean

--- a/config/install/field.field.paragraph.promotion_card.field_paragraph_link.yml
+++ b/config/install/field.field.paragraph.promotion_card.field_paragraph_link.yml
@@ -1,0 +1,43 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_paragraph_link
+    - paragraphs.paragraphs_type.promotion_card
+  module:
+    - link
+    - link_field_autocomplete_filter
+third_party_settings:
+  link_field_autocomplete_filter:
+    negate: null
+    allowed_content_types:
+      aboriginal_honour_roll: 0
+      alert: 0
+      event: 0
+      fv_recommendation: 0
+      grant: 0
+      landing_page: 0
+      news: 0
+      page: 0
+      profile: 0
+      publication: 0
+      publication_page: 0
+      sr_profile: 0
+      test: 0
+      translated_page: 0
+      vada_profile: 0
+      vdrp_profile: 0
+id: paragraph.promotion_card.field_paragraph_link
+field_name: field_paragraph_link
+entity_type: paragraph
+bundle: promotion_card
+label: Link
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 0
+field_type: link

--- a/config/install/field.field.paragraph.promotion_card.field_paragraph_media.yml
+++ b/config/install/field.field.paragraph.promotion_card.field_paragraph_media.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_paragraph_media
+    - media.type.image
+    - paragraphs.paragraphs_type.promotion_card
+id: paragraph.promotion_card.field_paragraph_media
+field_name: field_paragraph_media
+entity_type: paragraph
+bundle: promotion_card
+label: Image
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/install/field.field.paragraph.promotion_card.field_paragraph_summary.yml
+++ b/config/install/field.field.paragraph.promotion_card.field_paragraph_summary.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_paragraph_summary
+    - paragraphs.paragraphs_type.promotion_card
+id: paragraph.promotion_card.field_paragraph_summary
+field_name: field_paragraph_summary
+entity_type: paragraph
+bundle: promotion_card
+label: Summary
+description: 'This optional summary will be shown underneath the title.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/install/field.field.paragraph.promotion_card.field_paragraph_title.yml
+++ b/config/install/field.field.paragraph.promotion_card.field_paragraph_title.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_paragraph_title
+    - paragraphs.paragraphs_type.promotion_card
+id: paragraph.promotion_card.field_paragraph_title
+field_name: field_paragraph_title
+entity_type: paragraph
+bundle: promotion_card
+label: Title
+description: 'This title will be displayed as the primary call-to-action on the card.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/install/field.field.paragraph.promotion_card.field_promo_card_display_style.yml
+++ b/config/install/field.field.paragraph.promotion_card.field_promo_card_display_style.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_promo_card_display_style
+    - paragraphs.paragraphs_type.promotion_card
+  module:
+    - options
+id: paragraph.promotion_card.field_promo_card_display_style
+field_name: field_promo_card_display_style
+entity_type: paragraph
+bundle: promotion_card
+label: 'Card Display Style'
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    value: standard
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/install/field.storage.paragraph.field_customise.yml
+++ b/config/install/field.storage.paragraph.field_customise.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_customise
+field_name: field_customise
+entity_type: paragraph
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.paragraph.field_nav_card_display_style.yml
+++ b/config/install/field.storage.paragraph.field_nav_card_display_style.yml
@@ -4,8 +4,8 @@ dependencies:
   module:
     - options
     - paragraphs
-id: paragraph.field_promo_card_display_style
-field_name: field_promo_card_display_style
+id: paragraph.field_nav_card_display_style
+field_name: field_nav_card_display_style
 entity_type: paragraph
 type: list_string
 settings:
@@ -17,8 +17,8 @@ settings:
       value: thumbnail
       label: Thumbnail
     -
-      value: profile
-      label: Profile
+      value: featured
+      label: Featured
   allowed_values_function: ''
 module: options
 locked: false

--- a/config/install/field.storage.paragraph.field_promo_card_display_style.yml
+++ b/config/install/field.storage.paragraph.field_promo_card_display_style.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - paragraphs
+id: paragraph.field_promo_card_display_style
+field_name: field_promo_card_display_style
+entity_type: paragraph
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: standard
+      label: Standard
+    -
+      value: thumbnail
+      label: Thumbnail
+    -
+      value: profile
+      label: Profile
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/paragraphs.paragraphs_type.navigation_card.yml
+++ b/config/install/paragraphs.paragraphs_type.navigation_card.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies: {  }
+id: navigation_card
+label: 'Navigation card'
+icon_uuid: null
+icon_default: null
+description: ''
+behavior_plugins: {  }

--- a/config/install/paragraphs.paragraphs_type.promotion_card.yml
+++ b/config/install/paragraphs.paragraphs_type.promotion_card.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies: {  }
+id: promotion_card
+label: 'Promotion card'
+icon_uuid: null
+icon_default: null
+description: ''
+behavior_plugins: {  }

--- a/config/optional/jsonapi_extras.jsonapi_resource_config.paragraph--navigation_card.yml
+++ b/config/optional/jsonapi_extras.jsonapi_resource_config.paragraph--navigation_card.yml
@@ -2,11 +2,11 @@ langcode: en
 status: true
 dependencies:
   config:
-    - paragraphs.paragraphs_type.promotion_card
-id: paragraph--promotion_card
+    - paragraphs.paragraphs_type.navigation_card
+id: paragraph--navigation_card
 disabled: false
-path: paragraph/promotion_card
-resourceType: paragraph--promotion_card
+path: paragraph/navigation_card
+resourceType: paragraph--navigation_card
 resourceFields:
   id:
     fieldName: id
@@ -92,9 +92,9 @@ resourceFields:
     enhancer:
       id: ''
     disabled: false
-  field_promo_card_display_style:
-    fieldName: field_promo_card_display_style
-    publicName: field_promo_card_display_style
+  field_nav_card_display_style:
+    fieldName: field_nav_card_display_style
+    publicName: field_nav_card_display_style
     enhancer:
       id: ''
     disabled: false

--- a/config/optional/jsonapi_extras.jsonapi_resource_config.paragraph--promotion_card.yml
+++ b/config/optional/jsonapi_extras.jsonapi_resource_config.paragraph--promotion_card.yml
@@ -1,0 +1,130 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.promotion_card
+id: paragraph--promotion_card
+disabled: false
+path: paragraph/promotion_card
+resourceType: paragraph--promotion_card
+resourceFields:
+  id:
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+    disabled: false
+  uuid:
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+    disabled: false
+  revision_id:
+    fieldName: revision_id
+    publicName: revision_id
+    enhancer:
+      id: ''
+    disabled: false
+  langcode:
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+    disabled: false
+  type:
+    fieldName: type
+    publicName: type
+    enhancer:
+      id: ''
+    disabled: false
+  status:
+    fieldName: status
+    publicName: status
+    enhancer:
+      id: ''
+    disabled: false
+  created:
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''
+    disabled: false
+  parent_id:
+    fieldName: parent_id
+    publicName: parent_id
+    enhancer:
+      id: ''
+    disabled: false
+  parent_type:
+    fieldName: parent_type
+    publicName: parent_type
+    enhancer:
+      id: ''
+    disabled: false
+  parent_field_name:
+    fieldName: parent_field_name
+    publicName: parent_field_name
+    enhancer:
+      id: ''
+    disabled: false
+  behavior_settings:
+    fieldName: behavior_settings
+    publicName: behavior_settings
+    enhancer:
+      id: ''
+    disabled: false
+  default_langcode:
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+    disabled: false
+  revision_default:
+    fieldName: revision_default
+    publicName: revision_default
+    enhancer:
+      id: ''
+    disabled: false
+  revision_translation_affected:
+    fieldName: revision_translation_affected
+    publicName: revision_translation_affected
+    enhancer:
+      id: ''
+    disabled: false
+  field_promo_card_display_style:
+    fieldName: field_promo_card_display_style
+    publicName: field_promo_card_display_style
+    enhancer:
+      id: ''
+    disabled: false
+  field_customise:
+    fieldName: field_customise
+    publicName: field_customise
+    enhancer:
+      id: ''
+    disabled: false
+  field_paragraph_link:
+    fieldName: field_paragraph_link
+    publicName: field_paragraph_link
+    enhancer:
+      id: ''
+    disabled: false
+  field_paragraph_media:
+    fieldName: field_paragraph_media
+    publicName: field_paragraph_media
+    enhancer:
+      id: ''
+    disabled: false
+  field_paragraph_summary:
+    fieldName: field_paragraph_summary
+    publicName: field_paragraph_summary
+    enhancer:
+      id: ''
+    disabled: false
+  field_paragraph_title:
+    fieldName: field_paragraph_title
+    publicName: field_paragraph_title
+    enhancer:
+      id: ''
+    disabled: false

--- a/css/landing_page.css
+++ b/css/landing_page.css
@@ -2,3 +2,20 @@
   -webkit-flex-basis: 350px !important;;
   flex-basis: 350px !important;;
 }
+
+/* Custom css for navigation and promotion card paragraph type fields. */
+.paragraph-type--navigation-card .summary-message-group,
+.paragraph-type--navigation-card .customise-field-group,
+.paragraph-type--promotion-card .customise-field-group,
+.paragraph-type--promotion-card .summary-message-group {
+  background-color: transparent;
+  border: none;
+  padding-left: 0;
+}
+
+.paragraph-type--navigation-card .summary-message-group .fieldset-legend,
+.paragraph-type--navigation-card .customise-field-group .fieldset-legend,
+.paragraph-type--promotion-card .summary-message-group .fieldset-legend,
+.paragraph-type--promotion-card .customise-field-group .fieldset-legend {
+  text-transform: none;
+}

--- a/src/Plugin/jsonapi/FieldEnhancer/CardLinkEnhancer.php
+++ b/src/Plugin/jsonapi/FieldEnhancer/CardLinkEnhancer.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace Drupal\tide_landing_page\Plugin\jsonapi\FieldEnhancer;
+
+use Drupal\tide_media\Plugin\jsonapi\FieldEnhancer\ImageEnhancer;
+use Drupal\jsonapi_extras\Plugin\ResourceFieldEnhancerBase;
+use Drupal\paragraphs\Entity\Paragraph;
+use Drupal\taxonomy\Entity\Term;
+use Drupal\media\Entity\Media;
+use Drupal\file\Entity\File;
+use Shaper\Util\Context;
+
+/**
+ * Adds necessary fields from internal link.
+ *
+ * @ResourceFieldEnhancer(
+ *   id = "card_link_enhancer",
+ *   label = @Translation("Card Link Enhancer(Adds necessary fields from internal link)"),
+ *   description = @Translation("Adds necessary fields from internal link.")
+ * )
+ */
+class CardLinkEnhancer extends ResourceFieldEnhancerBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function doUndoTransform($data, Context $context) {
+    if (!empty($data) && (strpos($data['uri'], 'entity:node/') !== FALSE)) {
+      $nid = str_replace("entity:node/", "", $data['uri']);
+      if (!empty($nid)) {
+        $data['url'] = $this->getAlias($nid);
+        $data['image'] = $this->getImage($nid);
+        $data['internal_node_fields'] = $this->getCardFields($nid);
+      }
+    }
+    return $data;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function doTransform($data, Context $context) {
+    return $data;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getOutputJsonSchema() {
+    return [
+      'anyOf' => [
+        ['type' => 'object'],
+      ],
+    ];
+  }
+
+  /**
+   * Helper function to get alias for entity node.
+   *
+   * @param string $nid
+   *   The node id.
+   *
+   * @return string
+   *   The alias for node.
+   */
+  public function getAlias($nid) {
+    $url = '';
+    if (!empty($nid)) {
+      $aliasByPath = \Drupal::service('path.alias_manager')->getAliasByPath('/node/' . $nid);
+      $url = $this->getPathAliasWithoutSitePrefix(['alias' => $aliasByPath]);
+    }
+    return $url;
+  }
+
+  /**
+   * Helper function to get all the necessary node fields.
+   *
+   * @param string $nid
+   *   The node id.
+   *
+   * @return array
+   *   The array of fields value.
+   */
+  public function getCardFields($nid) {
+    $card_fields = [];
+    $node = \Drupal::entityTypeManager()->getStorage('node')->load($nid);
+    // Add title from the node.
+    $node_title = $node->get('title')->getValue();
+    $card_fields['title'] = $node_title ? $node_title[0]['value'] : '';
+    // Add summary from the node.
+    $summary = $node->hasField('field_landing_page_summary') ? $node->get('field_landing_page_summary')->getValue() : '';
+    $card_fields['summary'] = $summary ? $summary[0]['value'] : '';
+    // Add feature image from the node.
+    $feature_image = $node->hasField('field_featured_image') ? $node->get('field_featured_image')->getValue() : '';
+    $module_handler = \Drupal::moduleHandler();
+    if ($module_handler->moduleExists('tide_news')) {
+      // Add the summary field for news.
+      if ($node->hasField('body')) {
+        $news_summary = $node->get('body')->getValue() ? $node->get('body')->getValue()[0]['summary'] : '';
+        // If no news summary, will check for landing page summary.
+        $card_fields['summary'] = $news_summary ? $news_summary : $card_fields['summary'];
+      }
+      // Add the date field for news.
+      if ($node->hasField('field_news_date')) {
+        $card_fields['date'] = $node->get('field_news_date')->getValue()[0];
+        // This will ensure that it only adds topic from news node.
+        if ($card_fields['date']) {
+          $term_id = $node->hasField('field_topic') ? $node->get('field_topic')->getValue()[0]['target_id'] : '';
+          if ($term_id) {
+            $card_fields['topic'] = Term::load($term_id)->get('name')->value;
+          }
+        }
+      }
+    }
+    if ($module_handler->moduleExists('tide_event')) {
+      // Add event fields.
+      if ($node->hasField('field_event_details')) {
+        $paragraph_id = $node->get('field_event_details')->getValue()[0]['target_id'];
+        $paragraph = $paragraph_id ? Paragraph::load($paragraph_id) : '';
+        if ($paragraph && $paragraph->field_paragraph_date_range->getValue()) {
+          $event_date = $paragraph->field_paragraph_date_range->getValue()[0];
+          $card_fields['date'] = $event_date ? $event_date : '';
+        }
+        $location = $paragraph->field_paragraph_location->getValue() ? $paragraph->field_paragraph_location->getValue()[0]['locality'] : '';
+        if ($location) {
+          $card_fields['location'] = $location;
+        }
+        $event_author = $node->hasField('field_node_author') ? $node->get('field_node_author')->getValue() : '';
+        $card_fields['event_status'] = $event_author ? $event_author[0]['value'] : '';
+        $event_status = $node->hasField('field_status') ? $node->get('field_status')->getValue() : '';
+        $card_fields['event_status'] = $event_status ? $event_status[0]['value'] : '';
+        $term_id = $node->hasField('field_topic') ? $node->get('field_topic')->getValue()[0]['target_id'] : '';
+        if ($term_id) {
+          $card_fields['topic'] = Term::load($term_id)->get('name')->value;
+        }
+      }
+    }
+    return $card_fields;
+  }
+
+  /**
+   * Helper function to add image field details.
+   *
+   * @param string $nid
+   *   The node id.
+   *
+   * @return array
+   *   The image data with focal point values.
+   */
+  public function getImage($nid) {
+    $image = [];
+    $node = \Drupal::entityTypeManager()->getStorage('node')->load($nid);
+    if ($node->get('field_featured_image')->getValue()) {
+      $image_id = $node->get('field_featured_image')->getValue()[0]['target_id'];
+      $media = $image_id ? Media::load($image_id) : '';
+      // Get the ID of the media object image field.
+      $media_field = $media ? $media->get('field_media_image')->getValue() : '';
+      if ($media_field) {
+        // Image Details.
+        $image['data'] = $media_field;
+        $file = $media_field[0]['target_id'] ? File::load($media_field[0]['target_id']) : '';
+        if ($file) {
+          // Get URL of the image file.
+          $image['url'] = $file->url();
+          // Get image crop values.
+          $crop = !empty($file) ? ImageEnhancer::getCropEntity($file, 'focal_point') : '';
+          $focal_point = !empty($crop) ? $crop->position() : '';
+          $image['meta']['focal_point'] = $focal_point;
+        }
+      }
+    }
+    return $image;
+  }
+
+  /**
+   * Extract the original alias without site prefix.
+   *
+   * @param array $path
+   *   The path.
+   * @param string $site_base_url
+   *   The site base URL if the path alias is an absolute URL.
+   *
+   * @return string
+   *   The raw internal alias without site prefix.
+   */
+  public function getPathAliasWithoutSitePrefix(array $path, $site_base_url = '') {
+    $pattern = '/^\/site\-(\d+)\//';
+    if ($site_base_url) {
+      $pattern = '/' . preg_quote($site_base_url, '/') . '\/site\-(\d+)\//';
+    }
+    return preg_replace($pattern, $site_base_url . '/', $path['alias']);
+  }
+
+}

--- a/tests/behat/features/fields.feature
+++ b/tests/behat/features/fields.feature
@@ -269,11 +269,6 @@ Feature: Fields for Landing Page content type
     And I see field "field_landing_page_component[0][subform][field_customise][value]"
     And save screenshot
 
-  @api @nosuggest
-  Scenario: The content type has the expected fields (and labels where we can use them).
-    Given I am logged in as a user with the "create event content" permission
-    When I visit "node/add/event"
-    Then I see field "Parent event"
   @api @suggest @javascript
   Scenario: Request a landing page with an automated listing component via API
     Given vocabulary "topic" with name "Topic" exists

--- a/tests/behat/features/fields.feature
+++ b/tests/behat/features/fields.feature
@@ -71,6 +71,7 @@ Feature: Fields for Landing Page content type
     And I should see "Key dates" in the "select[name='field_landing_page_component[add_more][add_more_select]']" element
     And I should see "Image Gallery" in the "select[name='field_landing_page_component[add_more][add_more_select]']" element
     And I should see "Complex Image" in the "select[name='field_landing_page_component[add_more][add_more_select]']" element
+    And I should see "Promotion card" in the "select[name='field_landing_page_component[add_more][add_more_select]']" element
 
     And I see field "Tags"
     And I should see an "input#edit-field-tags-0-target-id" element
@@ -181,6 +182,7 @@ Feature: Fields for Landing Page content type
     And I should see "Key dates" in the "select[name='field_landing_page_component[add_more][add_more_select]']" element
     And I should see "Timelines" in the "select[name='field_landing_page_component[add_more][add_more_select]']" element
     And I should see "Complex Image" in the "select[name='field_landing_page_component[add_more][add_more_select]']" element
+    And I should see "Promotion card" in the "select[name='field_landing_page_component[add_more][add_more_select]']" element
 
     And I should see "Form embed (Drupal)" in the "select[name='field_landing_page_component[add_more][add_more_select]']" element
     And I should see "Form embed (OpenForms)" in the "select[name='field_landing_page_component[add_more][add_more_select]']" element
@@ -228,3 +230,21 @@ Feature: Fields for Landing Page content type
     And I see field "Background Colour"
     And I should see an "select#edit-field-landing-page-bg-colour" element
     And I should see an "select#edit-field-landing-page-bg-colour.required" element
+
+  @api @javascript
+  Scenario: The promotion card paragraph type has the expected fields.
+    Given I am logged in as a user with the "create landing_page content" permission
+    When I visit "node/add/landing_page"
+    And I click "Body Content"
+    Then I select "Promotion card" from "edit-field-landing-page-component-add-more-add-more-select"
+    And I press "edit-field-landing-page-component-add-more-add-more-button"
+    And I wait for 5 seconds
+    Then I see field "Link"
+    And I see field "Title"
+    And I see field "Summary"
+    And I see field "field_landing_page_component[0][subform][field_promo_card_display_style]"
+    And save screenshot
+    And I select "thumbnail" from "field_landing_page_component[0][subform][field_promo_card_display_style]"
+    And I wait for 5 seconds
+    And I see field "field_landing_page_component[0][subform][field_customise][value]"
+    And save screenshot

--- a/tide_landing_page.install
+++ b/tide_landing_page.install
@@ -1332,7 +1332,6 @@ function tide_landing_page_update_8033() {
   $config_storage->write($json_field, $config_read);
 }
 
-
 /**
  * Installs new navigation_card paragraph type.
  */
@@ -1428,7 +1427,7 @@ function tide_landing_page_update_8036() {
       'status' => TRUE,
       'dependencies' => [
         'entity_reference_revisions',
-        'paragraphs'
+        'paragraphs',
       ],
       'id' => 'paragraph.field_individual_cards',
       'field_name' => 'field_individual_cards',
@@ -1673,8 +1672,8 @@ function tide_landing_page_update_8036() {
               'enabled' => FALSE,
             ],
           ],
-        ]
-      ]
+        ],
+      ],
     ];
 
     $field = FieldConfig::loadByName($field_individual_cards['entity_type'], $bundle, $field_individual_cards['field_name']);

--- a/tide_landing_page.install
+++ b/tide_landing_page.install
@@ -1753,6 +1753,12 @@ function tide_landing_page_update_8037() {
     }
     $config->set('content', $content);
 
+    $hidden = $config->get('hidden');
+    if (isset($hidden['field_individual_cards'])) {
+      unset($hidden['field_individual_cards']);
+    }
+    $config->set('hidden', $hidden);
+
     $config->save();
   }
 }

--- a/tide_landing_page.install
+++ b/tide_landing_page.install
@@ -57,6 +57,7 @@ function tide_landing_page_install() {
   $field_config = FieldConfig::loadByName('node', 'landing_page', 'field_landing_page_component');
   if ($field_config) {
     $handler_settings = $field_config->getSetting('handler_settings');
+    $dependencies_settings = $field_config->getSetting('dependencies');
     // Add the Featured News paragraph to Landing Page component if exists.
     if ($moduleHandler->moduleExists('tide_news')) {
       $handler_settings['target_bundles']['featured_news'] = 'featured_news';
@@ -65,7 +66,20 @@ function tide_landing_page_install() {
     if ($moduleHandler->moduleExists('tide_webform')) {
       $handler_settings['target_bundles']['embedded_webform'] = 'embedded_webform';
     }
+    // Add the Automated Listing paragraph to Landing Page component if exists.
+    if ($moduleHandler->moduleExists('tide_automated_listing')) {
+      $handler_settings['target_bundles']['automated_card_listing'] = 'automated_card_listing';
+      $handler_settings['target_bundles_drag_drop'][] = [
+        'automated_card_listing' => [
+          'enabled' => TRUE,
+          'weight' => '-30',
+        ],
+      ];
+      $dependencies_settings['config'][] = 'paragraphs.paragraphs_type.automated_card_listing';
+    }
     $field_config->setSetting('handler_settings', $handler_settings);
+    $field_config->setSetting('dependencies', $dependencies_settings);
+
     $field_config->save();
   }
 
@@ -90,6 +104,11 @@ function tide_landing_page_install() {
       $config->set('bundles', $bundles)->save();
     }
   }
+
+  tide_landing_page_update_8036();
+  tide_landing_page_update_8037();
+  tide_landing_page_update_8038();
+  tide_landing_page_update_8039();
 }
 
 /**
@@ -1264,4 +1283,536 @@ function tide_landing_page_update_8032() {
   $description = 'The table of contents is automatically built from the heading structure of your page.';
   $field_config->set('description', $description);
   $field_config->save();
+}
+
+/**
+ * Installs new promotion_card paragraph type.
+ */
+function tide_landing_page_update_8033() {
+  $configs = [
+    'paragraphs.paragraphs_type.promotion_card' => 'paragraphs_type',
+    'field.storage.paragraph.field_promo_card_display_style' => 'field_storage_config',
+    'field.storage.paragraph.field_customise' => 'field_storage_config',
+    'field.field.paragraph.promotion_card.field_paragraph_title' => 'field_config',
+    'field.field.paragraph.promotion_card.field_paragraph_summary' => 'field_config',
+    'field.field.paragraph.promotion_card.field_paragraph_media' => 'field_config',
+    'field.field.paragraph.promotion_card.field_paragraph_link' => 'field_config',
+    'field.field.paragraph.promotion_card.field_customise' => 'field_config',
+    'field.field.paragraph.promotion_card.field_promo_card_display_style' => 'field_config',
+    'core.entity_view_display.paragraph.promotion_card.default' => 'entity_view_display',
+    'core.entity_form_display.paragraph.promotion_card.default' => 'entity_form_display',
+  ];
+  module_load_include('inc', 'tide_core', 'includes/helpers');
+  $config_location = [drupal_get_path('module', 'tide_landing_page') . '/config/install'];
+  // Check if field already exported to config/sync.
+  foreach ($configs as $config => $type) {
+    $config_read = _tide_read_config($config, $config_location, TRUE);
+    $storage = \Drupal::entityTypeManager()->getStorage($type);
+    $config_entity = $storage->createFromStorageRecord($config_read);
+    $config_entity->save();
+  }
+
+  // Add the new paragraph type to field_landing_page_component.
+  $field = FieldConfig::loadByName('node', 'landing_page', 'field_landing_page_component');
+  if ($field) {
+    $handler_settings = $field->getSetting('handler_settings');
+    if (isset($handler_settings['target_bundles']) && !in_array('promotion_card', $handler_settings['target_bundles'])) {
+      $handler_settings['target_bundles']['promotion_card'] = 'promotion_card';
+      $handler_settings['target_bundles_drag_drop']['promotion_card']['enabled'] = TRUE;
+      $field->setSetting('handler_settings', $handler_settings);
+      $field->save();
+    }
+  }
+
+  // Add paragraph type to JSON.
+  $json_field = 'jsonapi_extras.jsonapi_resource_config.paragraph--promotion_card';
+  $config_location = [drupal_get_path('module', 'tide_landing_page') . '/config/optional'];
+  $config_storage = \Drupal::service('config.storage');
+  $config_read = _tide_read_config($json_field, $config_location, TRUE);
+  $config_storage->write($json_field, $config_read);
+}
+
+
+/**
+ * Installs new navigation_card paragraph type.
+ */
+function tide_landing_page_update_8034() {
+  $configs = [
+    'paragraphs.paragraphs_type.navigation_card' => 'paragraphs_type',
+    'field.storage.paragraph.field_nav_card_display_style' => 'field_storage_config',
+    'field.field.paragraph.navigation_card.field_paragraph_title' => 'field_config',
+    'field.field.paragraph.navigation_card.field_paragraph_summary' => 'field_config',
+    'field.field.paragraph.navigation_card.field_paragraph_media' => 'field_config',
+    'field.field.paragraph.navigation_card.field_paragraph_link' => 'field_config',
+    'field.field.paragraph.navigation_card.field_customise' => 'field_config',
+    'field.field.paragraph.navigation_card.field_nav_card_display_style' => 'field_config',
+    'core.entity_view_display.paragraph.navigation_card.default' => 'entity_view_display',
+    'core.entity_form_display.paragraph.navigation_card.default' => 'entity_form_display',
+  ];
+  module_load_include('inc', 'tide_core', 'includes/helpers');
+  $config_location = [drupal_get_path('module', 'tide_landing_page') . '/config/install'];
+  // Check if field already exported to config/sync.
+  foreach ($configs as $config => $type) {
+    $config_read = _tide_read_config($config, $config_location, TRUE);
+    $storage = \Drupal::entityTypeManager()->getStorage($type);
+    $config_entity = $storage->createFromStorageRecord($config_read);
+    $config_entity->save();
+  }
+
+  // Add the new paragraph type to field_landing_page_component.
+  $field = FieldConfig::loadByName('node', 'landing_page', 'field_landing_page_component');
+  if ($field) {
+    $handler_settings = $field->getSetting('handler_settings');
+    if (isset($handler_settings['target_bundles']) && !in_array('navigation_card', $handler_settings['target_bundles'])) {
+      $handler_settings['target_bundles']['navigation_card'] = 'navigation_card';
+      $handler_settings['target_bundles_drag_drop']['navigation_card']['enabled'] = TRUE;
+      $field->setSetting('handler_settings', $handler_settings);
+      $field->save();
+    }
+  }
+
+  // Add paragraph type to JSON.
+  $json_field = 'jsonapi_extras.jsonapi_resource_config.paragraph--navigation_card';
+  $config_location = [drupal_get_path('module', 'tide_landing_page') . '/config/optional'];
+  $config_storage = \Drupal::service('config.storage');
+  $config_read = _tide_read_config($json_field, $config_location, TRUE);
+  $config_storage->write($json_field, $config_read);
+}
+
+/**
+ * Add the new paragraph type tide_automated_listing.
+ */
+function tide_landing_page_update_8035() {
+  $result = \Drupal::service('module_installer')->install(['tide_automated_listing']);
+  if (!$result) {
+    throw new \Exception(sprintf('Unable to install module %s', 'tide_automated_listing'));
+  }
+
+  /** @var \Drupal\Core\Extension\ModuleHandlerInterface $moduleHandler */
+  $moduleHandler = \Drupal::service('module_handler');
+  $field_config = FieldConfig::loadByName('node', 'landing_page', 'field_landing_page_component');
+  if ($field_config) {
+    $handler_settings = $field_config->getSetting('handler_settings');
+    $dependencies_settings = $field_config->getSetting('dependencies');
+
+    // Add the Automated Listing paragraph to Landing Page component if exists.
+    if ($moduleHandler->moduleExists('tide_automated_listing')) {
+      $handler_settings['target_bundles']['automated_card_listing'] = 'automated_card_listing';
+      $handler_settings['target_bundles_drag_drop'][] = [
+        'automated_card_listing' => [
+          'enabled' => TRUE,
+          'weight' => '-30',
+        ],
+      ];
+      $dependencies_settings['config'][] = 'paragraphs.paragraphs_type.automated_card_listing';
+    }
+    $field_config->setSetting('handler_settings', $handler_settings);
+    $field_config->setSetting('dependencies', $dependencies_settings);
+
+    $field_config->save();
+  }
+}
+
+/**
+ * Add the new field to paragraph type tide_automated_listing.
+ */
+function tide_landing_page_update_8036() {
+  /** @var \Drupal\Core\Extension\ModuleHandlerInterface $moduleHandler */
+  $moduleHandler = \Drupal::service('module_handler');
+
+  // Add the Automated Listing paragraph to Landing Page component if exists.
+  if ($moduleHandler->moduleExists('tide_automated_listing')) {
+    $bundle = 'automated_card_listing';
+    $field_individual_cards_storage = [
+      'langcode' => 'en',
+      'status' => TRUE,
+      'dependencies' => [
+        'entity_reference_revisions',
+        'paragraphs'
+      ],
+      'id' => 'paragraph.field_individual_cards',
+      'field_name' => 'field_individual_cards',
+      'entity_type' => 'paragraph',
+      'type' => 'entity_reference_revisions',
+      'settings' => [
+        'target_type' => 'paragraph',
+      ],
+      'module' => 'entity_reference_revisions',
+      'locked' => FALSE,
+      'cardinality' => -1,
+      'translatable' => TRUE,
+      'indexes' => [],
+      'persist_with_no_fields' => FALSE,
+      'custom_storage' => FALSE,
+    ];
+
+    $field_storage = FieldStorageConfig::loadByName($field_individual_cards_storage['entity_type'], $field_individual_cards_storage['field_name']);
+    if (empty($field_storage)) {
+      FieldStorageConfig::create($field_individual_cards_storage)->save();
+    }
+
+    $field_individual_cards = [
+      'langcode' => 'en',
+      'status' => TRUE,
+      'dependencies' => [
+        'config' => [
+          'field.storage.paragraph.field_individual_cards',
+          'paragraphs.paragraphs_type.automated_card_listing',
+          'paragraphs.paragraphs_type.navigation_card',
+        ],
+        'module' => [
+          'entity_reference_revisions',
+        ],
+      ],
+      'id' => 'paragraph.automated_card_listing.field_individual_cards',
+      'field_name' => 'field_individual_cards',
+      'entity_type' => 'paragraph',
+      'bundle' => 'automated_card_listing',
+      'label' => 'Individual cards',
+      'description' => '',
+      'required' => FALSE,
+      'translatable' => FALSE,
+      'default_value' => [],
+      'default_value_callback' => '',
+      'field_type' => 'entity_reference_revisions',
+      'settings' => [
+        'handler' => 'default:paragraph',
+        'handler_settings' => [
+          'negate' => 0,
+          'target_bundles' => [
+            'navigation_card' => 'navigation_card',
+          ],
+          'target_bundles_drag_drop' => [
+            'accordion' => [
+              'weight' => 39,
+              'enabled' => FALSE,
+            ],
+            'accordion_content' => [
+              'weight' => 40,
+              'enabled' => FALSE,
+            ],
+            'automated_card_listing' => [
+              'weight' => 41,
+              'enabled' => FALSE,
+            ],
+            'banner' => [
+              'weight' => 42,
+              'enabled' => FALSE,
+            ],
+            'basic_text' => [
+              'weight' => 43,
+              'enabled' => FALSE,
+            ],
+            'call_to_action' => [
+
+              'weight' => 44,
+              'enabled' => FALSE,
+            ],
+            'call_to_action_image' => [
+
+              'weight' => 45,
+              'enabled' => FALSE,
+            ],
+            'card_carousel' => [
+
+              'weight' => 46,
+              'enabled' => FALSE,
+            ],
+            'card_event' => [
+
+              'weight' => 47,
+              'enabled' => FALSE,
+            ],
+            'card_event_auto' => [
+
+              'weight' => 48,
+              'enabled' => FALSE,
+            ],
+            'card_keydates' => [
+
+              'weight' => 49,
+              'enabled' => FALSE,
+            ],
+            'card_navigation' => [
+
+              'weight' => 50,
+              'enabled' => FALSE,
+            ],
+            'card_navigation_auto' => [
+
+              'weight' => 51,
+              'enabled' => FALSE,
+            ],
+            'card_navigation_featured' => [
+
+              'weight' => 52,
+              'enabled' => FALSE,
+            ],
+            'card_navigation_featured_auto' => [
+
+              'weight' => 53,
+              'enabled' => FALSE,
+            ],
+            'card_promotion' => [
+
+              'enabled' => FALSE,
+              'weight' => 54,
+            ],
+            'card_promotion_auto' => [
+
+              'weight' => 55,
+              'enabled' => FALSE,
+            ],
+            'complex_image' => [
+
+              'weight' => 56,
+              'enabled' => FALSE,
+            ],
+            'contact_us' => [
+
+              'weight' => 57,
+              'enabled' => FALSE,
+            ],
+            'embedded_search_form' => [
+
+              'weight' => 58,
+              'enabled' => FALSE,
+            ],
+            'embedded_webform' => [
+
+              'weight' => 59,
+              'enabled' => FALSE,
+            ],
+            'event_details' => [
+
+              'weight' => 60,
+              'enabled' => FALSE,
+            ],
+            'featured_news' => [
+
+              'weight' => 61,
+              'enabled' => FALSE,
+            ],
+            'form_embed_openforms' => [
+
+              'weight' => 62,
+              'enabled' => FALSE,
+            ],
+            'hero_banner_with_cta' => [
+
+              'weight' => 63,
+              'enabled' => FALSE,
+            ],
+            'introduction_banner' => [
+
+              'weight' => 64,
+              'enabled' => FALSE,
+            ],
+            'key_journeys' => [
+
+              'weight' => 65,
+              'enabled' => FALSE,
+            ],
+            'keydates' => [
+
+              'weight' => 66,
+              'enabled' => FALSE,
+            ],
+            'latest_events' => [
+
+              'weight' => 67,
+              'enabled' => FALSE,
+            ],
+            'links' => [
+
+              'weight' => 68,
+              'enabled' => FALSE,
+            ],
+            'media_gallery' => [
+
+              'weight' => 69,
+              'enabled' => FALSE,
+            ],
+            'navigation_card' => [
+
+              'enabled' => TRUE,
+              'weight' => 70,
+            ],
+            'news_listing' => [
+
+              'weight' => 71,
+              'enabled' => FALSE,
+            ],
+            'phone' => [
+
+              'weight' => 72,
+              'enabled' => FALSE,
+            ],
+            'related_links' => [
+
+              'weight' => 73,
+              'enabled' => FALSE,
+            ],
+            'social_link' => [
+
+              'weight' => 74,
+              'enabled' => FALSE,
+            ],
+            'timeline' => [
+
+              'weight' => 75,
+              'enabled' => FALSE,
+            ],
+            'timelines' => [
+
+              'weight' => 76,
+              'enabled' => FALSE,
+            ],
+            'user_authentication_block' => [
+              'weight' => 77,
+              'enabled' => FALSE,
+            ],
+          ],
+        ]
+      ]
+    ];
+
+    $field = FieldConfig::loadByName($field_individual_cards['entity_type'], $bundle, $field_individual_cards['field_name']);
+    if (empty($field) && $bundle !== "" && !empty($bundle)) {
+      FieldConfig::create($field_individual_cards)->save();
+    }
+  }
+}
+
+/**
+ * Add individual cards to tide_automated_listing to entity form default.
+ */
+function tide_landing_page_update_8037() {
+  /** @var \Drupal\Core\Extension\ModuleHandlerInterface $moduleHandler */
+  $moduleHandler = \Drupal::service('module_handler');
+
+  // Add the Automated Listing paragraph to Landing Page component if exists.
+  if ($moduleHandler->moduleExists('tide_automated_listing')) {
+    $config_factory = \Drupal::configFactory();
+    $config = $config_factory->getEditable('core.entity_form_display.paragraph.automated_card_listing.default');
+
+    $dependencies_settings = $config->get('dependencies');
+    if (!in_array('field.field.paragraph.automated_card_listing.field_individual_cards', $dependencies_settings['config'])) {
+      $dependencies_settings['config'][] = 'field.field.paragraph.automated_card_listing.field_individual_cards';
+    }
+    $config->set('dependencies', $dependencies_settings);
+
+    $third_party_settings = $config->get('third_party_settings');
+    if (!in_array('field.field.paragraph.automated_card_listing.field_individual_cards', $third_party_settings['field_group']['group_card_collection']['children'])) {
+      $third_party_settings['field_group']['group_card_collection']['children'][] = 'group_individual_cards';
+    }
+    if (!isset($third_party_settings['field_group']['group_individual_cards'])) {
+      $third_party_settings['field_group']['group_individual_cards'] = [
+        'children' => [
+          'field_individual_cards',
+        ],
+        'parent_name' => 'group_card_collection',
+        'weight' => 20,
+        'format_type' => 'tab',
+        'region' => 'content',
+        'format_settings' => [
+          'id' => '',
+          'classes' => '',
+          'description' => '',
+          'formatter' => 'open',
+          'required_fields' => FALSE,
+        ],
+        'label' => 'Individual Cards',
+      ];
+    }
+    $config->set('third_party_settings', $third_party_settings);
+
+    $content = $config->get('content');
+    if (!isset($content['field_individual_cards'])) {
+      $content['field_individual_cards'] = [
+        'type' => 'preset_paragraphs',
+        'weight' => 13,
+        'settings' => [
+          'title' => 'Paragraph',
+          'title_plural' => 'Paragraphs',
+          'edit_mode' => 'open',
+          'add_mode' => 'dropdown',
+          'form_display_mode' => 'default',
+          'default_paragraph_type' => '',
+          'preset_number' => '',
+          'closed_mode' => 'summary',
+          'autocollapse' => 'none',
+          'closed_mode_threshold' => 0,
+          'features' => [
+            'duplicate' => 'duplicate',
+            'collapse_edit_all' => 'collapse_edit_all',
+          ],
+        ],
+        'third_party_settings' => [],
+        'region' => 'content',
+      ];
+    }
+    $config->set('content', $content);
+
+    $config->save();
+  }
+}
+
+/**
+ * Add individual cards to tide_automated_listing to entity view default.
+ */
+function tide_landing_page_update_8038() {
+  /** @var \Drupal\Core\Extension\ModuleHandlerInterface $moduleHandler */
+  $moduleHandler = \Drupal::service('module_handler');
+
+  // Add the Automated Listing paragraph to Landing Page component if exists.
+  if ($moduleHandler->moduleExists('tide_automated_listing')) {
+    $config_factory = \Drupal::configFactory();
+    $config = $config_factory->getEditable('core.entity_view_display.paragraph.automated_card_listing.default');
+
+    $dependencies_settings = $config->get('dependencies');
+    if (!in_array('field.field.paragraph.automated_card_listing.field_individual_cards', $dependencies_settings['config'])) {
+      $dependencies_settings['config'][] = 'field.field.paragraph.automated_card_listing.field_individual_cards';
+    }
+    if (!in_array('entity_reference_revisions', $dependencies_settings['module'])) {
+      $dependencies_settings['module'][] = 'entity_reference_revisions';
+    }
+    $config->set('dependencies', $dependencies_settings);
+
+    $hidden = $config->get('hidden');
+    if (!isset($hidden['field_individual_cards'])) {
+      $hidden['field_individual_cards'] = TRUE;
+    }
+    $config->set('hidden', $hidden);
+
+    $config->save();
+  }
+}
+
+/**
+ * Add individual cards to tide_automated_listing to entity view preview.
+ */
+function tide_landing_page_update_8039() {
+  /** @var \Drupal\Core\Extension\ModuleHandlerInterface $moduleHandler */
+  $moduleHandler = \Drupal::service('module_handler');
+
+  // Add the Automated Listing paragraph to Landing Page component if exists.
+  if ($moduleHandler->moduleExists('tide_automated_listing')) {
+    $config_factory = \Drupal::configFactory();
+    $config = $config_factory->getEditable('core.entity_view_display.paragraph.automated_card_listing.preview');
+
+    $dependencies_settings = $config->get('dependencies');
+    if (!in_array('field.field.paragraph.automated_card_listing.field_individual_cards', $dependencies_settings['config'])) {
+      $dependencies_settings['config'][] = 'field.field.paragraph.automated_card_listing.field_individual_cards';
+    }
+    $config->set('dependencies', $dependencies_settings);
+
+    $hidden = $config->get('hidden');
+    if (!isset($hidden['field_individual_cards'])) {
+      $hidden['field_individual_cards'] = TRUE;
+    }
+    $config->set('hidden', $hidden);
+
+    $config->save();
+  }
 }

--- a/tide_landing_page.module
+++ b/tide_landing_page.module
@@ -213,6 +213,13 @@ function tide_landing_page_field_widget_paragraphs_form_alter(&$element, FormSta
   }
 }
 
+/**
+ * Conditional display for navigation card.
+ *
+ * @param $paragraph_field_name
+ * @param $element
+ * @param $selector
+ */
 function _tide_landing_page_conditional_display_navigation_card($paragraph_field_name, &$element, $selector) {
   // Dependent fields.
   if (isset($element['subform']['field_paragraph_title'])) {

--- a/tide_landing_page.module
+++ b/tide_landing_page.module
@@ -57,7 +57,9 @@ function tide_landing_page_entity_bundle_create($entity_type_id, $bundle) {
 
       $is_featured_news = ($bundle == 'featured_news' && $moduleHandler->moduleExists('tide_news'));
       $is_embedded_webform = ($bundle == 'embedded_webform' && $moduleHandler->moduleExists('tide_webform'));
-      if ($is_featured_news || $is_embedded_webform) {
+      $is_automated_listing = ($bundle == 'automated_card_listing' && $moduleHandler->moduleExists('tide_automated_listing'));
+
+      if ($is_featured_news || $is_embedded_webform || $is_automated_listing) {
         $handler_settings['target_bundles'][$bundle] = $bundle;
         $field_config->setSetting('handler_settings', $handler_settings);
         $field_config->save();
@@ -73,6 +75,10 @@ function tide_landing_page_form_node_form_alter(&$form, FormStateInterface $form
   if (in_array($form_id, ['node_landing_page_form', 'node_landing_page_edit_form'])) {
     // Change form layout.
     $form['#attached']['library'][] = 'tide_landing_page/landing_page_form';
+    // Adding custom states from webform js.
+    if (\Drupal::moduleHandler()->moduleExists('webform')) {
+      $form['#attached']['library'][] = 'webform/webform.states';
+    }
 
     // Hide the field Show Acknowledgement to Country if tide_site is missing.
     if (!\Drupal::moduleHandler()->moduleExists('tide_site')) {
@@ -107,6 +113,14 @@ function tide_landing_page_form_node_form_alter(&$form, FormStateInterface $form
                 $form['field_landing_page_component']['widget'][$key]['subform']['field_paragraph_keydates']['widget'][$field]['top']['type']['label']['#markup'] = '<span class="paragraph-type-label"></span>';
               }
             }
+          }
+          if (isset($form['field_landing_page_component']['widget'][$key]['subform']['field_no_results_message'])) {
+            $form['field_landing_page_component']['widget'][$key]['subform']['field_no_results_message']['#states'] = [];
+            $form['field_landing_page_component']['widget'][$key]['subform']['field_no_results_message']['#states'] = [
+              'invisible' => [
+                ':input[name="field_landing_page_component[' . $key . '][subform][field_no_result_behaviour]"]' => ['value' => 'hide'],
+              ],
+            ];
           }
         }
       }
@@ -173,6 +187,134 @@ function tide_landing_page_field_widget_paragraphs_form_alter(&$element, FormSta
           }
         }
       }
+    }
+  }
+  if ($paragraph_field_name == 'field_landing_page_component') {
+    $widget_state = WidgetBase::getWidgetState($element['#field_parents'], $paragraph_field_name, $form_state);
+    $paragraph = $widget_state['paragraphs'][$element['#delta']]['entity'];
+    $paragraph_type = $paragraph->bundle();
+
+    if ($paragraph_type == 'automated_card_listing') {
+      foreach ($element['subform']['field_individual_cards']['widget'] as $key => $value) {
+        if (is_numeric($key)) {
+          $dependee_field_name = 'field_paragraph_link';
+          $selector = sprintf(':input[name^="%s[%d][subform][field_individual_cards][%d][subform][%s][0][uri]"]', $paragraph_field_name, $element['#delta'], $key, $dependee_field_name);
+          _tide_landing_page_conditional_display_navigation_card($paragraph_field_name, $element['subform']['field_individual_cards']['widget'][$key], $selector);
+        }
+      }
+    }
+
+    // Add states for navigation and promotion card paragraph type fields.
+    if ($paragraph_type == 'navigation_card' || $paragraph_type == 'promotion_card') {
+      $dependee_field_name = 'field_paragraph_link';
+      $selector = sprintf(':input[name^="%s[%d][subform][%s][0][uri]"]', $paragraph_field_name, $element['#delta'], $dependee_field_name);
+      _tide_landing_page_conditional_display_navigation_card($paragraph_field_name, $element, $selector);
+    }
+  }
+}
+
+function _tide_landing_page_conditional_display_navigation_card($paragraph_field_name, &$element, $selector) {
+  // Dependent fields.
+  if (isset($element['subform']['field_paragraph_title'])) {
+    $element['subform']['field_paragraph_title']['widget'][0]['value']['#states'] = [
+      'visible' => [
+        $selector => [
+          ['value' => ['pattern' => '^http']],
+          ['value' => ''],
+        ],
+      ],
+      'required' => [
+        $selector => [
+          ['value' => ['pattern' => '^http']],
+          ['value' => ''],
+        ],
+      ],
+    ];
+  }
+  if (isset($element['subform']['field_paragraph_summary'])) {
+    $element['subform']['field_paragraph_summary']['widget'][0]['value']['#states'] = [
+      'visible' => [
+        $selector => [
+          ['value' => ['pattern' => '^http']],
+          ['value' => ''],
+        ],
+      ],
+    ];
+    $element['subform']['summary_message_group'] = [
+      '#type' => 'fieldset',
+      '#title' => 'Page title & summary will be automatically drawn from the content you have linked to.',
+      '#group_name' => 'Page summary message',
+      '#attributes' => [
+        'class' => 'summary-message-group',
+      ],
+      '#states' => [
+        'invisible' => [
+          $selector => [
+            ['value' => ['pattern' => '^http']],
+            ['value' => ''],
+          ],
+        ],
+      ],
+    ];
+  }
+  if (isset($element['subform']['field_customise'])) {
+    $element['subform']['customise_field_group'] = [
+      '#type' => 'fieldset',
+      '#title' => 'Customise',
+      '#group_name' => 'Page summary message',
+      '#attributes' => [
+        'class' => 'customise-field-group',
+      ],
+      '#weight' => '20',
+      '#states' => [
+        'invisible' => [
+          $selector => [
+            ['value' => ['pattern' => '^http']],
+            ['value' => ''],
+          ],
+        ],
+      ],
+    ];
+    $element['subform']['field_customise']['#states'] = [
+      'invisible' => [
+        $selector => [
+          ['value' => ['pattern' => '^http']],
+          ['value' => ''],
+        ],
+      ],
+    ];
+    $element['subform']['customise_field_group']['field_customise'] = $element['subform']['field_customise'];
+    unset($element['subform']['field_customise']);
+  }
+  // Add state for media field.
+  $media_dependee_field_name = '';
+  $options = '';
+  if (isset($element['subform']['field_promo_card_display_style'])) {
+    $media_dependee_field_name = 'field_promo_card_display_style';
+    $options = [
+      ['value' => 'thumbnail'],
+      ['value' => 'profile'],
+    ];
+  }
+  if (isset($element['subform']['field_nav_card_display_style'])) {
+    $media_dependee_field_name = 'field_nav_card_display_style';
+    $options = [
+      ['value' => 'thumbnail'],
+      ['value' => 'featured'],
+    ];
+  }
+  if (!empty($media_dependee_field_name) && !empty($options)) {
+    $media_selector = sprintf(':input[name^="%s[%d][subform][%s]"]', $paragraph_field_name, $element['#delta'], $media_dependee_field_name);
+    // Dependent field.
+    if (isset($element['subform']['field_paragraph_media'])) {
+      $element['subform']['field_paragraph_media']['#states'] = [
+        'visible' => [
+          $media_selector => $options,
+          $selector => [
+            ['value' => ['pattern' => '^http']],
+          ],
+        ],
+      ];
     }
   }
 }

--- a/tide_landing_page.module
+++ b/tide_landing_page.module
@@ -215,10 +215,6 @@ function tide_landing_page_field_widget_paragraphs_form_alter(&$element, FormSta
 
 /**
  * Conditional display for navigation card.
- *
- * @param $paragraph_field_name
- * @param $element
- * @param $selector
  */
 function _tide_landing_page_conditional_display_navigation_card($paragraph_field_name, &$element, $selector) {
   // Dependent fields.


### PR DESCRIPTION
Related Ticket: https://digital-engagement.atlassian.net/browse/TVD-198

Related PR: https://github.com/dpc-sdp/tide_automated_listing/pull/2

This feature allows us to use navigation card as individual cards for card collection so that individual cards can be promoted.

**Added:**
- Merged card navigation + card promotion.
- Added individual cards for automated card collection

**Files To Review:**
- tide_landing_page.install
- tide_landing_page.module
- composer.json
- behat tests

**Note:**
This will not get merged as there is no requirement for SDP to start using this module so we will be using this feature branch for VT.