### PR TITLE
Directly copy link values to the new item

### DIFF
--- a/tide_landing_page.install
+++ b/tide_landing_page.install
@@ -1557,12 +1557,7 @@ function _get_link_value(Paragraph $paragraph) {
       if (!$paragraph->field_paragraph_link->isEmpty()) {
         $uri = $paragraph->field_paragraph_link->uri;
         $path_details = $paragraph->get('field_paragraph_link')->getValue();
-        if (!UrlHelper::isExternal($uri)) {
-          if (str_contains($uri, 'internal:/')) {
-            $uri = str_replace('internal:/', 'entity:', $uri);
-            $path_details[0]['uri'] = $uri;
-          }
-        }
+        $path_details[0]['uri'] = $uri;
         $path_details[1] = UrlHelper::isExternal($uri) ? 'external' : 'internal';
         $path_details[2] = 'field_paragraph_link';
       }
@@ -1591,12 +1586,7 @@ function _get_link_value(Paragraph $paragraph) {
       if (!$paragraph->field_paragraph_cta->isEmpty()) {
         $uri = $paragraph->field_paragraph_cta->uri;
         $path_details = $paragraph->get('field_paragraph_cta')->getValue();
-        if (!UrlHelper::isExternal($uri)) {
-          if (str_contains($uri, 'internal:/')) {
-            $uri = str_replace('internal:/', 'entity:', $uri);
-            $path_details[0]['uri'] = $uri;
-          }
-        }
+        $path_details[0]['uri'] = $uri;
         $path_details[1] = UrlHelper::isExternal($uri) ? 'external' : 'internal';
         $path_details[2] = 'field_paragraph_cta';
       }


### PR DESCRIPTION
### Motivation
1. Currently in new card system, we don't support `internal:/node/1` or `internal:/test-website` like links. 
2. @MdNadimHossain will create another PR for adding internal link support, updating the json enhancer, for new card system.
3. Reducing code complexity

### Changes
1. Just directly copy `uri` value to new paragraphs.