### PR TITLE
Runs update_35 only on a production (or prod-left) environment

### DIFF
--- a/tide_landing_page.install
+++ b/tide_landing_page.install
@@ -1365,6 +1365,9 @@ function tide_landing_page_update_8034() {
  * Updates cards.
  */
 function tide_landing_page_update_8035(&$sandbox) {
+  if (!getenv("TIDE_LANDING_PAGE_RUN_8035")) {
+    return;
+  }
   if (!isset($sandbox['total'])) {
     $paragraph_query = \Drupal::entityTypeManager()
       ->getStorage('paragraph')

--- a/tide_landing_page.install
+++ b/tide_landing_page.install
@@ -1365,7 +1365,7 @@ function tide_landing_page_update_8034() {
  * Updates cards.
  */
 function tide_landing_page_update_8035(&$sandbox) {
-  if (!getenv("TIDE_LANDING_PAGE_RUN_8035")) {
+  if (getenv("LAGOON_ENVIRONMENT_TYPE") != 'production') {
     return;
   }
   if (!isset($sandbox['total'])) {
@@ -1561,7 +1561,7 @@ function _get_link_value(Paragraph $paragraph) {
         $uri = $paragraph->field_paragraph_link->uri;
         $path_details = $paragraph->get('field_paragraph_link')->getValue();
         if (!UrlHelper::isExternal($uri)) {
-          if (str_contains($uri, 'internal:/')) {
+          if (strpos($uri, 'internal:/node/') !== FALSE) {
             $uri = str_replace('internal:/', 'entity:', $uri);
             $path_details[0]['uri'] = $uri;
           }
@@ -1595,7 +1595,7 @@ function _get_link_value(Paragraph $paragraph) {
         $uri = $paragraph->field_paragraph_cta->uri;
         $path_details = $paragraph->get('field_paragraph_cta')->getValue();
         if (!UrlHelper::isExternal($uri)) {
-          if (str_contains($uri, 'internal:/')) {
+          if (strpos($uri, 'internal:/node/') !== FALSE) {
             $uri = str_replace('internal:/', 'entity:', $uri);
             $path_details[0]['uri'] = $uri;
           }

--- a/tide_landing_page.post_update.php
+++ b/tide_landing_page.post_update.php
@@ -11,6 +11,9 @@ use Drupal\paragraphs\Entity\ParagraphsType;
  * Removes old paragraph types.
  */
 function tide_landing_page_post_update_remove_old_paragraph_types() {
+  if (!getenv("TIDE_LANDING_PAGE_RUN_8035")) {
+    return;
+  }
   $paragraph_types = [
     'card_navigation_featured_auto',
     'card_navigation_featured',

--- a/tide_landing_page.post_update.php
+++ b/tide_landing_page.post_update.php
@@ -11,7 +11,7 @@ use Drupal\paragraphs\Entity\ParagraphsType;
  * Removes old paragraph types.
  */
 function tide_landing_page_post_update_remove_old_paragraph_types() {
-  if (!getenv("TIDE_LANDING_PAGE_RUN_8035")) {
+  if (getenv("LAGOON_ENVIRONMENT_TYPE") != 'production') {
     return;
   }
   $paragraph_types = [


### PR DESCRIPTION
### Motivation
The running of [tide_landing_page_update_8035(&$sandbox)](https://github.com/dpc-sdp/tide_landing_page/pull/134/files#diff-7e6f6816fd76f77a0b74239e31ba4e5b1e332854d8e55ceae374edfe98dfe08bR1367) `update hook` for `[content-vic]` project takes about 2 hours, which may broke the build, therefore, after had discussion with @nicksantamaria and @GROwen ,  we would like to run this hook only in `production`(or prod-left) environment 


### Changes
1. check if `TIDE_LANDING_PAGE_RUN_8035` env variable exists, if it does , run the `tide_landing_page_update_8035()` update hook
2. change `str_contains()` to use `strpos()`. 