### PR TITLE
[SDPA-5058] Restrict block layout to administrators

### DIFF
--- a/src/Access/BlockAccessCheck.php
+++ b/src/Access/BlockAccessCheck.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Drupal\tide_landing_page\Access;
+
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Routing\Access\AccessInterface;
+
+/**
+ * Determines access for block layout based on roles.
+ */
+class BlockAccessCheck implements AccessInterface {
+
+  /**
+   * Checks access.
+   *
+   * @param Drupal\Core\Session\AccountInterface $account
+   *   The currently logged in account.
+   *
+   * @return bool
+   *   A \Drupal\Core\Access\AccessInterface constant value.
+   */
+  public function access(AccountInterface $account) {
+    $rolesWithAccessRestricted = [
+      'editor',
+      'approver',
+      'site_admin',
+    ];
+
+    $roleFound = FALSE;
+
+    $roles = $account->getRoles();
+    if (!empty($roles)) {
+      foreach ($roles as $role) {
+        if (in_array($role, $rolesWithAccessRestricted)) {
+          $roleFound = TRUE;
+          break;
+        }
+      }
+    }
+
+    if ($roleFound) {
+      return AccessResult::forbidden();
+    }
+
+    return AccessResult::allowed();
+  }
+
+}

--- a/src/Access/BlockAccessCheck.php
+++ b/src/Access/BlockAccessCheck.php
@@ -43,7 +43,7 @@ class BlockAccessCheck implements AccessInterface {
       return AccessResult::forbidden();
     }
 
-    return AccessResult::allowed();
+    return AccessResult::neutral();
   }
 
 }

--- a/src/Access/BlockAccessCheck.php
+++ b/src/Access/BlockAccessCheck.php
@@ -11,6 +11,15 @@ use Drupal\Core\Routing\Access\AccessInterface;
  */
 class BlockAccessCheck implements AccessInterface {
 
+  /**
+   * Checks access.
+   *
+   * @param Drupal\Core\Session\AccountInterface $account
+   *   The currently logged in account.
+   *
+   * @return bool
+   *   A \Drupal\Core\Access\AccessInterface constant value.
+   */
   public function access(AccountInterface $account) {
     return AccessResult::allowedIfHasPermission($account, 'administer content types');
   }

--- a/src/Access/BlockAccessCheck.php
+++ b/src/Access/BlockAccessCheck.php
@@ -43,4 +43,5 @@ class BlockAccessCheck implements AccessInterface {
     }
     return AccessResult::allowedIfHasPermission($account, 'administer content types');
   }
+
 }

--- a/src/Access/BlockAccessCheck.php
+++ b/src/Access/BlockAccessCheck.php
@@ -27,23 +27,20 @@ class BlockAccessCheck implements AccessInterface {
       'site_admin',
     ];
 
-    $roleFound = FALSE;
+    $isRestricted = FALSE;
 
     $roles = $account->getRoles();
     if (!empty($roles)) {
       foreach ($roles as $role) {
         if (in_array($role, $rolesWithAccessRestricted)) {
-          $roleFound = TRUE;
+          $isRestricted = TRUE;
           break;
         }
       }
     }
-
-    if ($roleFound) {
+    if ($isRestricted) {
       return AccessResult::forbidden();
     }
-
-    return AccessResult::neutral();
+    return AccessResult::allowedIfHasPermission($account, 'administer content types');
   }
-
 }

--- a/src/Access/BlockAccessCheck.php
+++ b/src/Access/BlockAccessCheck.php
@@ -11,36 +11,7 @@ use Drupal\Core\Routing\Access\AccessInterface;
  */
 class BlockAccessCheck implements AccessInterface {
 
-  /**
-   * Checks access.
-   *
-   * @param Drupal\Core\Session\AccountInterface $account
-   *   The currently logged in account.
-   *
-   * @return bool
-   *   A \Drupal\Core\Access\AccessInterface constant value.
-   */
   public function access(AccountInterface $account) {
-    $rolesWithAccessRestricted = [
-      'editor',
-      'approver',
-      'site_admin',
-    ];
-
-    $isRestricted = FALSE;
-
-    $roles = $account->getRoles();
-    if (!empty($roles)) {
-      foreach ($roles as $role) {
-        if (in_array($role, $rolesWithAccessRestricted)) {
-          $isRestricted = TRUE;
-          break;
-        }
-      }
-    }
-    if ($isRestricted) {
-      return AccessResult::forbidden();
-    }
     return AccessResult::allowedIfHasPermission($account, 'administer content types');
   }
 

--- a/src/Routing/RouteSubscriber.php
+++ b/src/Routing/RouteSubscriber.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Drupal\tide_landing_page\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Listens to the dynamic route events.
+ */
+class RouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection) {
+    if ($route = $collection->get('block.admin_display')) {
+      $route->setRequirement('_custom_access', 'Drupal\tide_landing_page\Access\BlockAccessCheck::access');
+    }
+
+  }
+
+}

--- a/tests/behat/features/access_block.feature
+++ b/tests/behat/features/access_block.feature
@@ -10,6 +10,6 @@ Feature: Check access to block layout
     Examples:
       | role               | response |
       | administrator      | 200      |
-      | editor             | 403      |
-      | approver           | 403      |
-      | site_admin         | 403      |
+      | editor             | 404      |
+      | approver           | 404      |
+      | site_admin         | 404      |

--- a/tests/behat/features/access_block.feature
+++ b/tests/behat/features/access_block.feature
@@ -1,0 +1,15 @@
+@tide
+Feature: Check access to block layout
+
+  @api
+  Scenario Outline: Approver, Editors and Site Admins can't have access to block layout
+    Given I am logged in as a user with the "<role>" role
+    When I go to "admin/structure/block/"
+    Then I should get a "<response>" HTTP response
+    And save screenshot
+    Examples:
+      | role               | response |
+      | administrator      | 200      |
+      | editor             | 403      |
+      | approver           | 403      |
+      | site_admin         | 403      |

--- a/tide_landing_page.links.menu.yml
+++ b/tide_landing_page.links.menu.yml
@@ -1,0 +1,5 @@
+tide_landing_page.block_library:
+  title: Custom Block Library
+  route_name: entity.block_content.collection
+  description: 'Manage blocks.'
+  parent: system.admin_structure

--- a/tide_landing_page.services.yml
+++ b/tide_landing_page.services.yml
@@ -1,0 +1,10 @@
+services:
+  tide_landing_page.route_subscriber:
+    class: Drupal\tide_landing_page\Routing\RouteSubscriber
+    tags:
+      - { name: event_subscriber }
+  tide_landing_page.access_block_checker:
+    class: Drupal\tide_landing_page\Access\BlockAccessCheck
+    arguments: ['@current_user']
+    tags:
+      - { name: access_check }


### PR DESCRIPTION
**JIRA issue:**
https://digital-engagement.atlassian.net/browse/SDPA-5058

**Changed**
Added new access checks
Added new event subscriber
Add custom menu item (Custom block library) under structure to allow users to create/manage blocks.

**Logic explanation**

- We need to restrict access the block layout for Approver/Site-Admin/Editor users and have a menu item visible for them to create/manage blocks.
- This won't arbitrary block/unblock all users access as it is specific for the roles requested on the ticket. Also, won't affect any other permissions.
- As a solution a custom menu item under structure have been added in order to allow Approver/Site-Admin/Editor users to create/manage blocks.
- Administrator role will be able to see this new custom menu item under structure. The fact of having another menu item to access block custom library won't impact on administrator users experience on the site.