### PR TITLE
[component-weight] Updated hook to get the new component weight and set it to sync config.

### DIFF
--- a/config/install/field.field.node.landing_page.field_landing_page_component.yml
+++ b/config/install/field.field.node.landing_page.field_landing_page_component.yml
@@ -14,6 +14,7 @@ dependencies:
     - paragraphs.paragraphs_type.card_promotion
     - paragraphs.paragraphs_type.card_promotion_auto
     - paragraphs.paragraphs_type.complex_image
+    - paragraphs.paragraphs_type.data_table
     - paragraphs.paragraphs_type.form_embed_openforms
     - paragraphs.paragraphs_type.latest_events
     - paragraphs.paragraphs_type.media_gallery
@@ -39,20 +40,21 @@ settings:
     target_bundles:
       basic_text: basic_text
       accordion: accordion
-      card_event: card_event
+      promotion_card: promotion_card
+      navigation_card: navigation_card
       card_keydates: card_keydates
-      call_to_action: call_to_action
-      complex_image: complex_image
+      card_carousel: card_carousel
       embedded_webform: embedded_webform
       form_embed_openforms: form_embed_openforms
       media_gallery: media_gallery
-      card_event_auto: card_event_auto
-      latest_events: latest_events
-      card_carousel: card_carousel
+      complex_image: complex_image
       timelines: timelines
+      call_to_action: call_to_action
+      latest_events: latest_events
       news_listing: news_listing
-      navigation_card: navigation_card
-      promotion_card: promotion_card
+      data_table: data_table
+      card_event: card_event
+      card_event_auto: card_event_auto
     target_bundles_drag_drop:
       banner:
         weight: -33
@@ -65,64 +67,67 @@ settings:
         weight: -31
       card_event:
         enabled: true
-        weight: -30
+        weight: -28
       card_promotion:
         enabled: false
-        weight: -29
+        weight: -27
       card_promotion_auto:
         enabled: false
-        weight: -28
+        weight: -26
       complex_image:
         enabled: true
-        weight: -28
+        weight: -17
+      data_table:
+        enabled: true
+        weight: -8
       key_journeys:
-        weight: -27
+        weight: -25
         enabled: false
       related_links:
-        weight: -26
+        weight: -24
         enabled: false
       links:
-        weight: -25
+        weight: -23
         enabled: false
       card_keydates:
         enabled: true
-        weight: -20
+        weight: -22
       accordion_content:
-        weight: -19
+        weight: -6
         enabled: false
       keydates:
-        weight: -18
+        weight: -5
         enabled: false
       call_to_action:
         enabled: true
-        weight: 21
+        weight: -12
       embedded_webform:
         enabled: true
-        weight: 22
+        weight: -20
       form_embed_openforms:
         enabled: true
-        weight: 23
+        weight: -19
       featured_news:
         enabled: true
         weight: 24
       news_listing:
         enabled: true
-        weight: 25
+        weight: -10
       navigation_card:
         enabled: true
-        weight: 26
+        weight: -29
       media_gallery:
         enabled: true
-        weight: 27
+        weight: -18
       card_event_auto:
         enabled: true
-        weight: 28
+        weight: -4
       latest_events:
         enabled: true
-        weight: 29
+        weight: -11
       card_carousel:
         enabled: true
-        weight: 29
+        weight: -21
       contact_us:
         weight: 34
         enabled: false
@@ -134,7 +139,7 @@ settings:
         enabled: false
       promotion_card:
         enabled: true
-        weight: 39
+        weight: -30
       social_link:
         weight: 40
         enabled: false
@@ -155,5 +160,5 @@ settings:
         enabled: false
       timelines:
         enabled: true
-        weight: 68
+        weight: -16
 field_type: entity_reference_revisions

--- a/tide_landing_page.install
+++ b/tide_landing_page.install
@@ -2191,13 +2191,20 @@ function tide_landing_page_update_8037() {
 }
 
 /**
- * Change icon of paragraph types.
+ * Change icon  and weight of paragraph types.
  */
 function tide_landing_page_update_8038() {
   module_load_include('inc', 'tide_core', 'includes/helpers');
+  $config_location = [drupal_get_path('module', 'tide_landing_page') . '/config/install'];
+  $config = 'field.field.node.landing_page.field_landing_page_component';
+  // Read only from /config/install.
+  $config_read = _tide_read_config($config, $config_location, FALSE);
+  // Get the sync file to update.
+  $config_factory = \Drupal::configFactory();
+  $config_sync = $config_factory->getEditable($config);
   $icon_dir = drupal_get_path('module', 'tide_landing_page') . DIRECTORY_SEPARATOR . 'icons';
-
   $paragraphs = [
+    'accordion',
     'basic_text',
     'call_to_action',
     'card_carousel',
@@ -2214,9 +2221,14 @@ function tide_landing_page_update_8038() {
     'navigation_card',
     'news_listing',
     'promotion_card',
+    'timelines',
   ];
   foreach ($paragraphs as $paragraph_type_id) {
+    // Changing icons.
     $icon_filename = $icon_dir . DIRECTORY_SEPARATOR . $paragraph_type_id . '.svg';
     _tide_set_paragraph_type_icon($paragraph_type_id, $icon_filename);
+    // Changing weight.
+    $new_weight = $config_read['settings']['handler_settings']['target_bundles_drag_drop'][$paragraph_type_id]['weight'];
+    $config_sync->set('settings.handler_settings.target_bundles_drag_drop.'.$paragraph_type_id.'.weight', $new_weight)->save();
   }
 }

--- a/tide_landing_page.install
+++ b/tide_landing_page.install
@@ -2229,6 +2229,6 @@ function tide_landing_page_update_8038() {
     _tide_set_paragraph_type_icon($paragraph_type_id, $icon_filename);
     // Changing weight.
     $new_weight = $config_read['settings']['handler_settings']['target_bundles_drag_drop'][$paragraph_type_id]['weight'];
-    $config_sync->set('settings.handler_settings.target_bundles_drag_drop.'.$paragraph_type_id.'.weight', $new_weight)->save();
+    $config_sync->set('settings.handler_settings.target_bundles_drag_drop.' . $paragraph_type_id . '.weight', $new_weight)->save();
   }
 }


### PR DESCRIPTION
### Jira - https://digital-engagement.atlassian.net/browse/SDPA-4995

### Issue -
The component sequence was fixed only for content-vic and the weight wasn't updated in this module. 

### Changes
Updated the component sequence matching Duncan's comment from the ticket and copying the weight from content-vic, so the sequence of components that belongs to tide_ladning_page stays the same for all projects.