### PR TITLE
Added missing tablefield module dependency.

### DIFF
--- a/tide_landing_page.info.yml
+++ b/tide_landing_page.info.yml
@@ -12,6 +12,7 @@ dependencies:
   - drupal:node
   - drupal:path
   - drupal:text
+  - drupal:tablefield
   - drupal:telephone
   - drupal:user
   - dpc-sdp:tide_core


### PR DESCRIPTION
Hi,

### Problem
When installing the module, I get the following error:

`In UnmetDependenciesException.php line 98:
                                                                                                                                                                                                             Configuration objects provided by <em class="placeholder">tide_landing_page</em> have unmet dependencies: <em class="placeholder">core.entity_form_display.paragraph.data_table.default (tablefield)</em>  `

The Tablefield module is pulled in via composer in `tide_core`, however, it is not enabled, which causes this hiccup during clean installation.

### Solution

I have added `tablefield` module as a dependency via the info file, which would ensure that the `tablefield` module is installed before configuration is sync'ed.
