### PR TITLE
[SDPA-5105] Added hook to clear reference node cahce on presave.

### DIFF
--- a/tide_landing_page.module
+++ b/tide_landing_page.module
@@ -5,9 +5,11 @@
  * Tide Landing Page module functionality.
  */
 
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
 use Drupal\field\Entity\FieldConfig;
+use Drupal\node\NodeInterface;
 use Drupal\workflows\Entity\Workflow;
 use Drupal\Core\Field\WidgetBase;
 
@@ -471,4 +473,54 @@ function _tide_landing_page_form_node_form_after_build(array $form, FormStateInt
   $form['_header_style']['_header_style_options']['#default_value'] = $header_style;
 
   return $form;
+}
+
+/**
+ * Get all referenced nodes for a node in promotion & navigation card paragraph.
+ *
+ * @param \Drupal\node\NodeInterface $node
+ *   The node context.
+ *
+ * @return null|array
+ *   The node ids.
+ */
+function _tide_landing_page_get_all_ref_nodes(NodeInterface $node) {
+  try {
+    $query = \Drupal::entityTypeManager()->getStorage('paragraph')->getQuery();
+    $query->condition('field_paragraph_link', 'entity:node/' . $node->id());
+    $or = $query->orConditionGroup();
+    $or->condition('type', 'navigation_card');
+    $or->condition('type', 'promotion_card');
+    $result = $query->condition($or)->execute();
+    if ($result) {
+      $node_ids = \Drupal::database()
+        ->select('paragraphs_item_field_data', 'para')
+        ->fields('para', ['parent_id'])
+        ->condition('id', $result, 'IN')
+        ->execute()->fetchCol();
+      if ($node_ids) {
+        $cids = [];
+        foreach ($node_ids as $node_id) {
+          $cids[] = 'node:' . $node_id;
+        }
+        return $cids;
+      }
+    }
+  }
+  catch (\Exception $exception) {
+    watchdog_exception('tide_landing_page_get_all_ref_nodes', $exception);
+  }
+  return NULL;
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_presave().
+ */
+function tide_landing_page_node_presave(NodeInterface $node) {
+  if (!$node->isNew()) {
+    $cids = _tide_landing_page_get_all_ref_nodes($node);
+    if(!empty($cids)) {
+      Cache::invalidateTags($cids);
+    }
+  }
 }

--- a/tide_landing_page.module
+++ b/tide_landing_page.module
@@ -519,7 +519,7 @@ function _tide_landing_page_get_all_ref_nodes(NodeInterface $node) {
 function tide_landing_page_node_presave(NodeInterface $node) {
   if (!$node->isNew()) {
     $cids = _tide_landing_page_get_all_ref_nodes($node);
-    if(!empty($cids)) {
+    if (!empty($cids)) {
       Cache::invalidateTags($cids);
     }
   }

--- a/tide_landing_page.module
+++ b/tide_landing_page.module
@@ -485,30 +485,23 @@ function _tide_landing_page_form_node_form_after_build(array $form, FormStateInt
  *   The node ids.
  */
 function _tide_landing_page_get_all_ref_nodes(NodeInterface $node) {
-  try {
-    $query = \Drupal::entityTypeManager()->getStorage('paragraph')->getQuery();
-    $query->condition('field_paragraph_link', 'entity:node/' . $node->id());
+  if ($node->id()) {
+    $query = \Drupal::database()->select('paragraphs_item_field_data', 'p');
+    $query->fields('p', ['parent_id']);
+    $query->fields('pl', ['field_paragraph_link_uri']);
+    $query->leftJoin('paragraph__field_paragraph_link', 'pl', 'pl.entity_id = p.id');
+    $query->condition('pl.field_paragraph_link_uri', 'entity:node/' . $node->id());
     $or = $query->orConditionGroup();
     $or->condition('type', 'navigation_card');
     $or->condition('type', 'promotion_card');
-    $result = $query->condition($or)->execute();
-    if ($result) {
-      $node_ids = \Drupal::database()
-        ->select('paragraphs_item_field_data', 'para')
-        ->fields('para', ['parent_id'])
-        ->condition('id', $result, 'IN')
-        ->execute()->fetchCol();
-      if ($node_ids) {
-        $cids = [];
-        foreach ($node_ids as $node_id) {
-          $cids[] = 'node:' . $node_id;
-        }
-        return $cids;
+    $node_ids = $query->condition($or)->execute()->fetchCol();
+    if ($node_ids) {
+      $cids = [];
+      foreach ($node_ids as $node_id) {
+        $cids[] = 'node:' . $node_id;
       }
+      return $cids;
     }
-  }
-  catch (\Exception $exception) {
-    watchdog_exception('tide_landing_page_get_all_ref_nodes', $exception);
   }
   return NULL;
 }


### PR DESCRIPTION
### Jira - 
https://digital-engagement.atlassian.net/browse/SDPA-5105

### Issue -
if the promotion and navigation card has an internal link referenced in it and when the internal link node gets updated, the details does not get updated in the cards where the node is referenced.

### Changes
1. Added a function to query the nodes that are referencing a particual node in the promotion and navigation card.
2. Added node pre-save hook to clear cache for all the parent nodes where the current node is referred.

### Test branch
FE test link - https://app.pr-864.vic-gov-au.sdp2.sdp.vic.gov.au/
BE test link - https://nginx-php.pr-1172.content-vic.sdp2.sdp.vic.gov.au/