### PR TITLE
[SDPA-5332] Added paragraph bundle issue fix.

### DIFF
--- a/tide_landing_page.module
+++ b/tide_landing_page.module
@@ -181,7 +181,7 @@ function tide_landing_page_field_widget_paragraphs_form_alter(&$element, FormSta
   $paragraph_field_name = $field_definition->getName();
   $widget_state = WidgetBase::getWidgetState($element['#field_parents'], $paragraph_field_name, $form_state);
   $paragraph = $widget_state['paragraphs'][$element['#delta']]['entity'];
-  $paragraph_type = $paragraph->bundle();
+  $paragraph_type = $paragraph ? $paragraph->bundle() : '';
 
   switch ($paragraph_type) {
     case 'embedded_search_form':
@@ -225,7 +225,7 @@ function tide_landing_page_field_widget_paragraphs_form_alter(&$element, FormSta
   if ($paragraph_field_name === 'field_landing_page_component') {
     $widget_state = WidgetBase::getWidgetState($element['#field_parents'], $paragraph_field_name, $form_state);
     $paragraph = $widget_state['paragraphs'][$element['#delta']]['entity'];
-    $paragraph_type = $paragraph->bundle();
+    $paragraph_type = $paragraph ? $paragraph->bundle() : '';
     // Hide table caption field in Data table component.
     if ($paragraph_type == 'data_table') {
       unset($element['subform']['field_data_table_content']['widget'][0]['caption']);


### PR DESCRIPTION
### Jira - 
https://digital-engagement.atlassian.net/browse/SDPA-5332

### Issue -
This is really an uncommon issue. There is a page in vicpol BE named careers and at some point the field_landing_page_component had 2 components in it. One of them got removed, but the delta element somehow didn't get updated and the delta element still points it has 2 components in it.
For this reason in `tide_landing_page_field_widget_paragraphs_form_alter` hook here `$paragraph = $widget_state['paragraphs'][$element['#delta']]['entity'];` the value of #delta gives 0 and 1 value. When it tries to get the paragraph for value 1 it returns null. Because of that this throws error on calling function on null `$paragraph->bundle();`

Rather than fix these kinds of issue using db query, I think best to put a check for empty paragraph and even this kind of issue occurs, in the next save of the node it will get fixed.
See the screenshot below for referrence.
### Changes
1. Added check for empty paragraph before calling the` bundle()` function on it.

### Screenshot
The page that has 0 and 1 as delta values but only 1 component in the `field_landing_page_component`

![Screen Shot 2021-07-28 at 12 24 55 pm](https://user-images.githubusercontent.com/20810541/127274206-cb1dab55-7ea2-4ce6-8023-362d6ad1de92.png)

The page that has a proper delta value that matches with the number of components in the field
![Screen Shot 2021-07-28 at 12 25 12 pm](https://user-images.githubusercontent.com/20810541/127274318-19ef0798-da67-4489-92cf-d0abcf220378.png)
