### PR TITLE
[SDPA-5406] Removed reduandant summary field for tide_news module.

### DIFF
--- a/src/Plugin/jsonapi/FieldEnhancer/CardLinkEnhancer.php
+++ b/src/Plugin/jsonapi/FieldEnhancer/CardLinkEnhancer.php
@@ -120,13 +120,6 @@ class CardLinkEnhancer extends ResourceFieldEnhancerBase {
     }
     $module_handler = \Drupal::moduleHandler();
     if ($module_handler->moduleExists('tide_news')) {
-      // Add the summary field for news.
-      // This needs to be updated with the CMS improvement changes in tide_news.
-      if ($node->hasField('body') && !$node->body->isEmpty()) {
-        $news_summary = $node->get('body')->getValue()[0]['summary'];
-        // If no news summary, will check for landing page summary.
-        $card_fields['summary'] = $news_summary ? $news_summary : '';
-      }
       // Add the date field for news.
       if ($node->hasField('field_news_date') && !$node->field_news_date->isEmpty()) {
         $card_fields['date'] = $node->get('field_news_date')->getValue()[0];


### PR DESCRIPTION
### Jira - 
https://digital-engagement.atlassian.net/browse/SDPA-5406

### Issue -
The card link enhancer sends out the empty summary for the news content type cause the summary field that was attached to the body field for the news content type does not exist anymore.


### Changes
1. As the summary field that is attached to the body field for news content type is redundant now, this needs to be updated in the card link enhancer so that it doesn't have to look for the news content type-specific summary field anymore.

### Testing Prs - 
FE test link - https://app.pr-1012.ripple.sdp2.sdp.vic.gov.au/
BE test link - https://nginx-php.pr-1174.content-vic.sdp2.sdp.vic.gov.au/

### Screenshot
