### PR TITLE
Implemented Embed custom component

### DIFF
--- a/config/install/core.entity_form_display.paragraph.custom_component.default.yml
+++ b/config/install/core.entity_form_display.paragraph.custom_component.default.yml
@@ -1,0 +1,34 @@
+uuid: 46092c39-9323-46ca-8b2d-dcdf547ed727
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.custom_component.field_paragraph_custom_component
+    - field.field.paragraph.custom_component.field_paragraph_options
+    - paragraphs.paragraphs_type.custom_component
+id: paragraph.custom_component.default
+targetEntityType: paragraph
+bundle: custom_component
+mode: default
+content:
+  field_paragraph_custom_component:
+    weight: 0
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+  field_paragraph_options:
+    weight: 1
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textarea
+    region: content
+hidden:
+  created: true
+  status: true

--- a/config/install/core.entity_form_display.taxonomy_term.custom_components.default.yml
+++ b/config/install/core.entity_form_display.taxonomy_term.custom_components.default.yml
@@ -1,0 +1,54 @@
+uuid: db01cd4f-d664-4a19-a210-2af387e60900
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.custom_components.field_default_options
+    - field.field.taxonomy_term.custom_components.field_machine_name
+    - taxonomy.vocabulary.custom_components
+  module:
+    - path
+id: taxonomy_term.custom_components.default
+targetEntityType: taxonomy_term
+bundle: custom_components
+mode: default
+content:
+  field_default_options:
+    weight: 2
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textarea
+    region: content
+  field_machine_name:
+    weight: 1
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 4
+    region: content
+    third_party_settings: {  }
+hidden:
+  description: true

--- a/config/install/core.entity_view_display.paragraph.custom_component.default.yml
+++ b/config/install/core.entity_view_display.paragraph.custom_component.default.yml
@@ -1,0 +1,30 @@
+uuid: c24c7c70-c8ed-4c94-8c80-88c84756dcd2
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.custom_component.field_paragraph_custom_component
+    - field.field.paragraph.custom_component.field_paragraph_options
+    - paragraphs.paragraphs_type.custom_component
+id: paragraph.custom_component.default
+targetEntityType: paragraph
+bundle: custom_component
+mode: default
+content:
+  field_paragraph_custom_component:
+    weight: 1
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_paragraph_options:
+    weight: 0
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/config/install/core.entity_view_display.taxonomy_term.custom_components.default.yml
+++ b/config/install/core.entity_view_display.taxonomy_term.custom_components.default.yml
@@ -1,0 +1,31 @@
+uuid: c84828b8-0bee-42b4-bc58-f38363e43e77
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.custom_components.field_default_options
+    - field.field.taxonomy_term.custom_components.field_machine_name
+    - taxonomy.vocabulary.custom_components
+id: taxonomy_term.custom_components.default
+targetEntityType: taxonomy_term
+bundle: custom_components
+mode: default
+content:
+  field_default_options:
+    weight: 1
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+  field_machine_name:
+    weight: 0
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden:
+  description: true
+  search_api_excerpt: true

--- a/config/install/field.field.node.landing_page.field_landing_page_component.yml
+++ b/config/install/field.field.node.landing_page.field_landing_page_component.yml
@@ -14,6 +14,7 @@ dependencies:
     - paragraphs.paragraphs_type.card_promotion
     - paragraphs.paragraphs_type.card_promotion_auto
     - paragraphs.paragraphs_type.complex_image
+    - paragraphs.paragraphs_type.custom_component
     - paragraphs.paragraphs_type.data_table
     - paragraphs.paragraphs_type.form_embed_openforms
     - paragraphs.paragraphs_type.latest_events
@@ -55,6 +56,7 @@ settings:
       data_table: data_table
       card_event: card_event
       card_event_auto: card_event_auto
+      custom_component: custom_component
     target_bundles_drag_drop:
       banner:
         weight: -33
@@ -128,6 +130,9 @@ settings:
       contact_us:
         weight: 34
         enabled: false
+      custom_component:
+        enabled: true
+        weight: 75
       call_to_action_image:
         weight: 35
         enabled: false

--- a/config/install/field.field.paragraph.custom_component.field_paragraph_custom_component.yml
+++ b/config/install/field.field.paragraph.custom_component.field_paragraph_custom_component.yml
@@ -1,0 +1,29 @@
+uuid: e1e8a24c-b820-4a0e-ba32-fb8da614cc46
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_paragraph_custom_component
+    - paragraphs.paragraphs_type.custom_component
+    - taxonomy.vocabulary.custom_components
+id: paragraph.custom_component.field_paragraph_custom_component
+field_name: field_paragraph_custom_component
+entity_type: paragraph
+bundle: custom_component
+label: 'Custom component'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      custom_components: custom_components
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/install/field.field.paragraph.custom_component.field_paragraph_options.yml
+++ b/config/install/field.field.paragraph.custom_component.field_paragraph_options.yml
@@ -1,0 +1,19 @@
+uuid: a5aa411b-e7e6-41ef-a8f6-b59ccc7ada5b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_paragraph_options
+    - paragraphs.paragraphs_type.custom_component
+id: paragraph.custom_component.field_paragraph_options
+field_name: field_paragraph_options
+entity_type: paragraph
+bundle: custom_component
+label: Options
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/install/field.field.taxonomy_term.custom_components.field_default_options.yml
+++ b/config/install/field.field.taxonomy_term.custom_components.field_default_options.yml
@@ -1,0 +1,19 @@
+uuid: 469052a7-9ba5-47c3-942f-2bd690d311a3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_default_options
+    - taxonomy.vocabulary.custom_components
+id: taxonomy_term.custom_components.field_default_options
+field_name: field_default_options
+entity_type: taxonomy_term
+bundle: custom_components
+label: 'Default options'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/install/field.field.taxonomy_term.custom_components.field_machine_name.yml
+++ b/config/install/field.field.taxonomy_term.custom_components.field_machine_name.yml
@@ -1,0 +1,19 @@
+uuid: 99693f6e-71c8-4daf-8f89-7053906d581f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_machine_name
+    - taxonomy.vocabulary.custom_components
+id: taxonomy_term.custom_components.field_machine_name
+field_name: field_machine_name
+entity_type: taxonomy_term
+bundle: custom_components
+label: 'Machine name'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/install/field.storage.paragraph.field_paragraph_custom_component.yml
+++ b/config/install/field.storage.paragraph.field_paragraph_custom_component.yml
@@ -1,0 +1,20 @@
+uuid: 2fcb55b0-f7e2-4772-bd18-6a918bb0acce
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - taxonomy
+id: paragraph.field_paragraph_custom_component
+field_name: field_paragraph_custom_component
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.paragraph.field_paragraph_options.yml
+++ b/config/install/field.storage.paragraph.field_paragraph_options.yml
@@ -1,0 +1,19 @@
+uuid: 770ba688-fb82-4ead-bbd7-f24a78f70835
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_paragraph_options
+field_name: field_paragraph_options
+entity_type: paragraph
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.taxonomy_term.field_default_options.yml
+++ b/config/install/field.storage.taxonomy_term.field_default_options.yml
@@ -1,0 +1,19 @@
+uuid: 7808b156-6bbf-402b-9d16-0bde2d7f1f66
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_default_options
+field_name: field_default_options
+entity_type: taxonomy_term
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.taxonomy_term.field_machine_name.yml
+++ b/config/install/field.storage.taxonomy_term.field_machine_name.yml
@@ -1,0 +1,21 @@
+uuid: 36350735-a9f3-4bdc-af62-4ee76a15e4e7
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_machine_name
+field_name: field_machine_name
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/paragraphs.paragraphs_type.custom_component.yml
+++ b/config/install/paragraphs.paragraphs_type.custom_component.yml
@@ -1,0 +1,10 @@
+uuid: e82518d1-950b-4d20-bb88-cfeaadade7b7
+langcode: en
+status: true
+dependencies: {  }
+id: custom_component
+label: 'Custom component'
+icon_uuid: null
+icon_default: null
+description: 'Used to embedded custom component on the front end.'
+behavior_plugins: {  }

--- a/config/install/taxonomy.vocabulary.custom_components.yml
+++ b/config/install/taxonomy.vocabulary.custom_components.yml
@@ -1,0 +1,8 @@
+uuid: 6f37d308-eb62-4b4d-beac-a610a3be06da
+langcode: en
+status: true
+dependencies: {  }
+name: 'Custom components'
+vid: custom_components
+description: ''
+weight: 0

--- a/config/optional/jsonapi_extras.jsonapi_resource_config.node--landing_page.yml
+++ b/config/optional/jsonapi_extras.jsonapi_resource_config.node--landing_page.yml
@@ -224,7 +224,7 @@ resourceFields:
     fieldName: field_landing_page_component
     publicName: field_landing_page_component
     enhancer:
-      id: ''
+      id: page_components_enhancer
     disabled: false
     advancedOptionsIcon: ''
     enhancer_label: ''

--- a/config/optional/jsonapi_extras.jsonapi_resource_config.paragraph--custom_component.yml
+++ b/config/optional/jsonapi_extras.jsonapi_resource_config.paragraph--custom_component.yml
@@ -1,0 +1,107 @@
+uuid: 5089bd12-07a9-4a21-9030-539140a5de2f
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.custom_component
+id: paragraph--custom_component
+disabled: false
+path: paragraph/custom_component
+resourceType: paragraph--custom_component
+resourceFields:
+  id:
+    fieldName: id
+    publicName: id
+    enhancer:
+      id: ''
+    disabled: false
+  uuid:
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+    disabled: false
+  revision_id:
+    fieldName: revision_id
+    publicName: revision_id
+    enhancer:
+      id: ''
+    disabled: false
+  langcode:
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+    disabled: false
+  type:
+    fieldName: type
+    publicName: type
+    enhancer:
+      id: ''
+    disabled: false
+  status:
+    fieldName: status
+    publicName: status
+    enhancer:
+      id: ''
+    disabled: false
+  created:
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''
+    disabled: false
+  parent_id:
+    fieldName: parent_id
+    publicName: parent_id
+    enhancer:
+      id: ''
+    disabled: false
+  parent_type:
+    fieldName: parent_type
+    publicName: parent_type
+    enhancer:
+      id: ''
+    disabled: false
+  parent_field_name:
+    fieldName: parent_field_name
+    publicName: parent_field_name
+    enhancer:
+      id: ''
+    disabled: false
+  behavior_settings:
+    fieldName: behavior_settings
+    publicName: behavior_settings
+    enhancer:
+      id: ''
+    disabled: false
+  default_langcode:
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+    disabled: false
+  revision_default:
+    fieldName: revision_default
+    publicName: revision_default
+    enhancer:
+      id: ''
+    disabled: false
+  revision_translation_affected:
+    fieldName: revision_translation_affected
+    publicName: revision_translation_affected
+    enhancer:
+      id: ''
+    disabled: false
+  field_paragraph_custom_component:
+    fieldName: field_paragraph_custom_component
+    publicName: field_paragraph_custom_component
+    enhancer:
+      id: ''
+    disabled: false
+  field_paragraph_options:
+    fieldName: field_paragraph_options
+    publicName: field_paragraph_options
+    enhancer:
+      id: ''
+    disabled: false

--- a/src/Plugin/Validation/Constraint/JsonValidationConstraint.php
+++ b/src/Plugin/Validation/Constraint/JsonValidationConstraint.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\vicgovau_core\Plugin\Validation\Constraint;
+
+use Drupal\Core\Entity\Plugin\Validation\Constraint\CompositeConstraintBase;
+
+/**
+ * Verify that the JSON string is valid.
+ *
+ * @Constraint(
+ *   id = "JsonValidation",
+ *   label = @Translation("Json Validation", context = "Validation"),
+ *   type = "string"
+ * )
+ */
+class JsonValidationConstraint extends CompositeConstraintBase {
+
+  /**
+   * Error message for invalid JSON string.
+   *
+   * @var string
+   */
+  public $jsonValidationError = 'The %field field should contain a valid JSON string.';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function coversFields() {
+    return ['field_paragraph_options', 'field_default_options'];
+  }
+
+}

--- a/src/Plugin/Validation/Constraint/JsonValidationConstraintValidator.php
+++ b/src/Plugin/Validation/Constraint/JsonValidationConstraintValidator.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Drupal\vicgovau_core\Plugin\Validation\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Validates the Json Validation constraint.
+ */
+class JsonValidationConstraintValidator extends ConstraintValidator {
+
+  /**
+   * Validator 2.5 and upwards compatible execution context.
+   *
+   * @var \Symfony\Component\Validator\Context\ExecutionContextInterface
+   */
+  protected $context;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validate($entity, Constraint $constraint) {
+    if ($entity->hasField('field_paragraph_options')) {
+      $this->addConstraint($entity, $constraint, 'field_paragraph_options');
+    }
+
+    if ($entity->hasField('field_default_options')) {
+      $this->addConstraint($entity, $constraint, 'field_default_options');
+    }
+
+    // If the fields do not exist, do not validate anything.
+    return NULL;
+  }
+
+  /**
+   * Helper to add constraint.
+   */
+  protected function addConstraint($entity, $constraint, $field) {
+    $jsonString = $entity->get($field)->getValue();
+    $jsonString = (count($jsonString) == 1 ? $jsonString[0]['value'] : FALSE);
+
+    if (strlen($jsonString)) {
+      if (!$this->isValidJson($jsonString)) {
+        $this->context->buildViolation($constraint->jsonValidationError)
+          ->setParameter('%field', $entity->getFieldDefinition($field)->label())
+          ->atPath($field)
+          ->addViolation();
+      }
+    }
+  }
+
+  /**
+   * Helper to check for valid JSON string.
+   */
+  protected function isValidJson($string) {
+    if (is_string($string)) {
+      if (is_array(json_decode($string, TRUE)) && (json_last_error() == JSON_ERROR_NONE)) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+}

--- a/src/Plugin/jsonapi/FieldEnhancer/PageComponentEnhancer.php
+++ b/src/Plugin/jsonapi/FieldEnhancer/PageComponentEnhancer.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Drupal\vicgovau_core\Plugin\jsonapi\FieldEnhancer;
+
+use Drupal\jsonapi_extras\Plugin\ResourceFieldEnhancerBase;
+use Shaper\Util\Context;
+use Drupal\taxonomy\Entity\Term;
+
+/**
+ * Perform additional manipulations to page component fields.
+ *
+ * Page Component Enhancer is used to to fetch the field value details of
+ * the taxonomy referenced in the custom component paragraph and
+ * add those fields key value pair to the current API json output.
+ *
+ * @ResourceFieldEnhancer(
+ *   id = "page_components_enhancer",
+ *   label = @Translation("Page Component Enhancer (includes Overwrite for paragraphs)"),
+ *   description = @Translation("Includes Additional Custom Details")
+ * )
+ */
+class PageComponentEnhancer extends ResourceFieldEnhancerBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function doUndoTransform($data, Context $context) {
+    // Custom components paragraph enhancer.
+    if (!empty($data) && !empty($data['type']) && $data['type'] == 'paragraph--custom_component') {
+      $paragraph = \Drupal::service('entity.repository')->loadEntityByUuid('paragraph', $data['id']);
+      if (!$paragraph->get('field_paragraph_custom_component')->isEmpty()) {
+        $termId = $paragraph->get('field_paragraph_custom_component')->target_id;
+        $term = Term::load($termId);
+        $field_machine_name = $term->get('field_machine_name')->value;
+        $field_paragraph_custom_component = "";
+        if (!$paragraph->get('field_paragraph_options')->isEmpty()) {
+          $field_paragraph_custom_component = $paragraph->get('field_paragraph_options')->value;
+        }
+        elseif (!$term->get('field_default_options')->isEmpty()) {
+          $field_paragraph_custom_component = $term->get('field_default_options')->value;
+        }
+        $data['meta']['machine_name'] = $field_machine_name;
+        $data['meta']['custom_component'] = $field_paragraph_custom_component;
+      }
+    }
+    return $data;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function doTransform($data, Context $context) {
+    if (isset($data['meta']['machine_name'])) {
+      unset($data['meta']['machine_name']);
+    }
+    if (isset($data['meta']['custom_component'])) {
+      unset($data['meta']['custom_component']);
+    }
+    return $data;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getOutputJsonSchema() {
+    return [
+      'anyOf' => [
+        ['type' => 'array'],
+        ['type' => 'null'],
+        ['type' => 'object'],
+      ],
+    ];
+  }
+
+}

--- a/tests/behat/features/custom_components.feature
+++ b/tests/behat/features/custom_components.feature
@@ -1,0 +1,40 @@
+Feature: Check the Custom components taxonomy
+
+  Ensure Custom components vocabulary exist.
+
+  @api
+  Scenario: Custom components taxonomy vocabulary exists
+    Given vocabulary "custom_components" with name "Custom components" exists
+    When I am logged in as a user with the "Site Admin" role
+    And I go to "admin/structure/taxonomy/manage/custom_components/add"
+    Then I see field "Name"
+    And I should see an "input#edit-name-0-value.required" element
+    And I see field "Machine name"
+    And I should see an "input#edit-field-machine-name-0-value.required" element
+    And I see field "Default options"
+    And I should not see an "input#edit-field-default-options-0-value.required" element
+    And I don't see field "Description"
+
+  @api @nosuggest
+  Scenario: The content type has the expected valid fields (Custom Component) JSON Validation.
+    Given I am logged in as a user with the "site_admin" role
+    When I visit "admin/structure/taxonomy/manage/custom_components/add"
+    And I fill in the following:
+      | name[0][value]                  | Testing title 1                     |
+      | field_machine_name[0][value]    | machine_name                        |
+      | field_default_options[0][value] | [{"user_id":13,"username":"stack"}] |
+    And I press "Save"
+    And I wait for 2 seconds
+    And I should see text matching "Testing title 1"
+
+  @api @nosuggest
+  Scenario: The content type has the expected invalid fields (Custom Component) JSON Validation.
+    Given I am logged in as a user with the "site_admin" role
+    When I visit "admin/structure/taxonomy/manage/custom_components/add"
+    And I fill in the following:
+      | name[0][value]                  | Testing title   |
+      | field_machine_name[0][value]    | machine_name    |
+      | field_default_options[0][value] | test wrong json |
+    And I press "Save"
+    And I wait for 2 seconds
+    And I should see text matching "The Default options field should contain a valid JSON string."

--- a/tests/behat/features/fields.feature
+++ b/tests/behat/features/fields.feature
@@ -305,3 +305,76 @@ Feature: Fields for Landing Page content type
     # This field can be "seen" but not visible.
     And I see field "field_landing_page_component[0][subform][field_customise][value]"
     And save screenshot
+
+  @api @nosuggest
+  Scenario: The content type has the expected valid fields (Custom Component).
+    Given custom_components terms:
+      | name             | field_machine_name:value | field_default_options:value         |
+      | Test Component 1 | test_machine_name        | [{"user_id":13,"username":"stack"}] |
+    Given sites terms:
+      | name        |
+      | Test Site 1 |
+    Given topic terms:
+      | name         |
+      | Test Topic 1 |
+    Given department terms:
+      | name              | tid    |
+      | Test Department 1 | 300001 |
+    Given I am logged in as a user with the "site_admin" role
+    When I visit "node/add/landing_page"
+    And I press the "edit-field-landing-page-component-add-more-add-modal-form-area-add-more" button
+    And I should see the button "Custom component"
+    And I wait for 5 seconds
+    And I press the "Custom component" button
+    And I wait for 5 seconds
+    And I see field "Custom component"
+    And I should see an "input[id$=edit-field-landing-page-component-0-subform-field-paragraph-custom-component-0-target-id]" element
+    And I should see an "input[id$=edit-field-landing-page-component-0-subform-field-paragraph-custom-component-0-target-id].required" element
+    And I see field "Options"
+    And I should see an "textarea[id$=edit-field-landing-page-component-0-subform-field-paragraph-options-0-value]" element
+    And I should not see an "textarea[id$=edit-field-landing-page-component-0-subform-field-paragraph-options-0-value].required" element
+    And I fill in the following:
+      | title[0][value]                                                                          | Testing title                                                        |
+      | field_landing_page_summary[0][value]                                                     | Test summary                                                         |
+      | field_landing_page_component[0][subform][field_paragraph_options][0][value]              | [{"user_id":13,"username":"stack"},{"user_id":14,"username":"over"}] |
+      | field_landing_page_component[0][subform][field_paragraph_custom_component][0][target_id] | Test Component 1                                                     |
+      | field_topic[0][target_id]                                                                | Test Topic 1                                                         |
+      | field_department_agency                                                                  | 300001                                                               |
+    And I check "Test Site 1"
+    And I select "Published" from "edit-moderation-state-0-state"
+    And I press "Save"
+    And I wait for 2 seconds
+    And I should see text matching "Testing title"
+
+  @api @nosuggest
+  Scenario: The content type has the expected invalid fields (Custom Component) JSON Validation.
+    Given custom_components terms:
+      | name             | field_machine_name:value | field_default_options:value         |
+      | Test Component 1 | test_machine_name        | [{"user_id":13,"username":"stack"}] |
+    Given sites terms:
+      | name        |
+      | Test Site 1 |
+    Given topic terms:
+      | name         |
+      | Test Topic 1 |
+    Given department terms:
+      | name              | tid    |
+      | Test Department 1 | 300001 |
+    Given I am logged in as a user with the "site_admin" role
+    When I visit "node/add/landing_page"
+    And I press the "edit-field-landing-page-component-add-more-add-modal-form-area-add-more" button
+    And I wait for 5 seconds
+    And I press the "Custom component" button
+    And I wait for 5 seconds
+    And I fill in the following:
+      | title[0][value]                                                                          | Testing title    |
+      | field_landing_page_summary[0][value]                                                     | Test summary     |
+      | field_landing_page_component[0][subform][field_paragraph_options][0][value]              | test wrong json  |
+      | field_landing_page_component[0][subform][field_paragraph_custom_component][0][target_id] | Test Component 1 |
+      | field_topic[0][target_id]                                                                | Test Topic 1     |
+      | field_department_agency                                                                  | 300001           |
+    And I check "Test Site 1"
+    And I select "Published" from "edit-moderation-state-0-state"
+    And I press "Save"
+    And I wait for 2 seconds
+    And I should see text matching "The Options field should contain a valid JSON string."

--- a/tide_landing_page.info.yml
+++ b/tide_landing_page.info.yml
@@ -46,6 +46,7 @@ config_devel:
     - core.entity_form_display.paragraph.card_promotion.default
     - core.entity_form_display.paragraph.card_promotion_auto.default
     - core.entity_form_display.paragraph.complex_image.default
+    - core.entity_form_display.paragraph.custom_component.default
     - core.entity_form_display.paragraph.embedded_search_form.default
     - core.entity_form_display.paragraph.form_embed_openforms.default
     - core.entity_form_display.paragraph.key_journeys.default
@@ -55,6 +56,7 @@ config_devel:
     - core.entity_form_display.paragraph.media_gallery.default
     - core.entity_form_display.paragraph.hero_banner_with_cta.default
     - core.entity_form_display.paragraph.introduction_banner.default
+    - core.entity_form_display.taxonomy_term.custom_components.default
     - core.entity_view_display.block_content.media_gallery.default
     - core.entity_view_display.block_content.campaign_with_video.default
     - core.entity_view_display.node.landing_page.card
@@ -75,6 +77,7 @@ config_devel:
     - core.entity_view_display.paragraph.card_promotion_auto.default
     - core.entity_view_display.paragraph.card_promotion.default
     - core.entity_view_display.paragraph.complex_image.default
+    - core.entity_view_display.paragraph.custom_component.default
     - core.entity_view_display.paragraph.embedded_search_form.default
     - core.entity_view_display.paragraph.form_embed_openforms.default
     - core.entity_view_display.paragraph.hero_banner_with_cta.default
@@ -90,6 +93,7 @@ config_devel:
     - core.entity_view_display.paragraph.news_listing.default
     - core.entity_view_display.paragraph.phone.default
     - core.entity_view_display.paragraph.social_link.default
+    - core.entity_view_display.taxonomy_term.custom_components.default
     - field.field.block_content.campaign.body
     - field.field.block_content.campaign.field_block_cta
     - field.field.block_content.campaign.field_block_image
@@ -174,6 +178,8 @@ config_devel:
     - field.field.paragraph.complex_image.field_complex_image_media
     - field.field.paragraph.complex_image.field_complex_image_source
     - field.field.paragraph.complex_image.field_complex_image_title
+    - field.field.paragraph.custom_component.field_paragraph_custom_component
+    - field.field.paragraph.custom_component.field_paragraph_options
     - field.field.paragraph.embedded_search_form.field_paragraph_search_block
     - field.field.paragraph.embedded_search_form.field_paragraph_search_ph
     - field.field.paragraph.embedded_search_form.field_paragraph_search_target
@@ -215,6 +221,8 @@ config_devel:
     - field.field.paragraph.phone.field_paragraph_phone_title
     - field.field.paragraph.social_link.field_paragraph_link
     - field.field.paragraph.social_link.field_paragraph_social_list
+    - field.field.taxonomy_term.custom_components.field_default_options
+    - field.field.taxonomy_term.custom_components.field_machine_name
     - field.storage.block_content.field_block_cta
     - field.storage.block_content.field_block_image
     - field.storage.block_content.field_block_title
@@ -249,6 +257,7 @@ config_devel:
     - field.storage.paragraph.field_complex_image_media
     - field.storage.paragraph.field_complex_image_source
     - field.storage.paragraph.field_complex_image_title
+    - field.storage.paragraph.field_paragraph_custom_component
     - field.storage.paragraph.field_form_link
     - field.storage.paragraph.field_paragraph_date
     - field.storage.paragraph.field_paragraph_freetext
@@ -261,6 +270,7 @@ config_devel:
     - field.storage.paragraph.field_paragraph_keydates
     - field.storage.paragraph.field_paragraph_topic
     - field.storage.paragraph.field_paragraph_email
+    - field.storage.paragraph.field_paragraph_options
     - field.storage.paragraph.field_paragraph_name
     - field.storage.paragraph.field_paragraph_news_reference
     - field.storage.paragraph.field_paragraph_phone_number
@@ -273,6 +283,8 @@ config_devel:
     - field.storage.paragraph.field_paragraph_social_list
     - field.storage.paragraph.field_paragraph_social_media
     - field.storage.paragraph.field_paragraph_webform
+    - field.storage.taxonomy_term.field_default_options
+    - field.storage.taxonomy_term.field_machine_name
     - node.type.landing_page
     - paragraphs.paragraphs_type.banner
     - paragraphs.paragraphs_type.basic_text
@@ -297,10 +309,12 @@ config_devel:
     - paragraphs.paragraphs_type.latest_events
     - paragraphs.paragraphs_type.media_gallery
     - paragraphs.paragraphs_type.contact_us
+    - paragraphs.paragraphs_type.custom_component
     - paragraphs.paragraphs_type.news_listing
     - paragraphs.paragraphs_type.phone
     - paragraphs.paragraphs_type.social_link
     - paragraphs.paragraphs_type.timelines
+    - taxonomy.vocabulary.custom_components
   optional:
     - core.entity_form_display.paragraph.embedded_webform.default
     - core.entity_form_display.paragraph.featured_news.default
@@ -319,6 +333,7 @@ config_devel:
     - jsonapi_extras.jsonapi_resource_config.paragraph--card_navigation
     - jsonapi_extras.jsonapi_resource_config.paragraph--card_navigation_featured
     - jsonapi_extras.jsonapi_resource_config.paragraph--card_promotion
+    - jsonapi_extras.jsonapi_resource_config.paragraph--custom_component
     - jsonapi_extras.jsonapi_resource_config.paragraph--featured_news
     - jsonapi_extras.jsonapi_resource_config.paragraph--form_embed_openforms
     - jsonapi_extras.jsonapi_resource_config.paragraph-.hero_banner_with_cta

--- a/tide_landing_page.install
+++ b/tide_landing_page.install
@@ -2350,3 +2350,75 @@ function tide_landing_page_update_8040() {
     }
   }
 }
+
+/**
+ * Installs new custom_component paragraph type.
+ */
+function tide_landing_page_update_8041() {
+  $configs = [
+    'taxonomy.vocabulary.custom_components' => 'vocabulary',
+    'paragraphs.paragraphs_type.custom_component' => 'paragraphs_type',
+    'field.storage.paragraph.field_paragraph_custom_component' => 'field_storage_config',
+    'field.storage.paragraph.field_paragraph_options' => 'field_storage_config',
+    'field.storage.taxonomy_term.field_default_options' => 'field_storage_config',
+    'field.storage.taxonomy_term.field_machine_name' => 'field_storage_config',
+    'field.field.paragraph.custom_component.field_paragraph_custom_component' => 'field_config',
+    'field.field.paragraph.custom_component.field_paragraph_options' => 'field_config',
+    'field.field.taxonomy_term.custom_components.field_default_options' => 'field_config',
+    'field.field.taxonomy_term.custom_components.field_machine_name' => 'field_config',
+    'core.entity_view_display.paragraph.custom_component.default' => 'entity_view_display',
+    'core.entity_view_display.taxonomy_term.custom_components.default' => 'entity_view_display',
+    'core.entity_form_display.paragraph.custom_component.default' => 'entity_form_display',
+    'core.entity_form_display.taxonomy_term.custom_components.default' => 'entity_form_display',
+  ];
+  module_load_include('inc', 'tide_core', 'includes/helpers');
+  $config_location = [drupal_get_path('module', 'tide_landing_page') . '/config/install'];
+  // Check if field already exported to config/sync.
+  foreach ($configs as $config => $type) {
+    $config_read = _tide_read_config($config, $config_location, TRUE);
+    $storage = \Drupal::entityTypeManager()->getStorage($type);
+    $id = $storage->getIDFromConfigName($config, $storage->getEntityType()->getConfigPrefix());
+    if ($storage->load($id) == NULL) {
+      $config_entity = $storage->createFromStorageRecord($config_read);
+      $config_entity->save();
+    }
+  }
+
+  // Add the new paragraph type to field_landing_page_component.
+  $field = FieldConfig::loadByName('node', 'landing_page', 'field_landing_page_component');
+  if ($field) {
+    $handler_settings = $field->getSetting('handler_settings');
+    if (isset($handler_settings['target_bundles']) && !in_array('custom_component', $handler_settings['target_bundles'])) {
+      $handler_settings['target_bundles']['custom_component'] = 'custom_component';
+      $handler_settings['target_bundles_drag_drop']['custom_component']['enabled'] = TRUE;
+      $field->setSetting('handler_settings', $handler_settings);
+      $field->save();
+    }
+  }
+
+  $config_factory = \Drupal::configFactory();
+  $config = $config_factory->getEditable('jsonapi_extras.jsonapi_resource_config.node--landing_page');
+
+  $content = $config->get('resourceFields');
+  if (isset($content['field_landing_page_component'])) {
+    $content['field_landing_page_component'] = [
+      'fieldName' => 'field_landing_page_component',
+      'publicName' => 'field_landing_page_component',
+      'enhancer' => [
+        'id' => 'page_components_enhancer',
+      ],
+      'disabled' => FALSE,
+      'advancedOptionsIcon' => '',
+      'enhancer_label' => '',
+    ];
+
+    $config->set('resourceFields', $content);
+  }
+
+  // Add paragraph type to JSON.
+  $json_field = 'jsonapi_extras.jsonapi_resource_config.paragraph--custom_component';
+  $config_location = [drupal_get_path('module', 'tide_landing_page') . '/config/optional'];
+  $config_storage = \Drupal::service('config.storage');
+  $config_read = _tide_read_config($json_field, $config_location, TRUE);
+  $config_storage->write($json_field, $config_read);
+}

--- a/tide_landing_page.module
+++ b/tide_landing_page.module
@@ -517,3 +517,12 @@ function tide_landing_page_node_presave(NodeInterface $node) {
     }
   }
 }
+
+/**
+ * Implements hook_entity_type_build().
+ */
+function tide_landing_page_entity_type_build(array &$entity_types) {
+  // Add our custom validation to the options field.
+  $entity_types['paragraph']->addConstraint('JsonValidation');
+  $entity_types['taxonomy_term']->addConstraint('JsonValidation');
+}


### PR DESCRIPTION
Created a vocabulary - Custom components 
AddedJSON format validation for Options field
Exported configs
Added behat test
Created a paragraph type - Custom component
Enabled this paragraph type in the Content components field (Landing page)
AddedJSON format validation for Options field
Added JSONAPI enhancer to output component options from default parameters taken from the taxonomy terms OR use overrides from the specified Options field.
Behat tests for paragraph

On-behalf-of: @salsadigitalauorg joshua.fernandes@salsadigital.com.au