### PR TITLE
[SDPA-6056] Fix Spinner overlapping in confirm removal dropdown

### DIFF
--- a/css/landing_page.css
+++ b/css/landing_page.css
@@ -38,3 +38,9 @@
   text-transform: none;
   letter-spacing: normal;
 }
+
+.dropbutton-multiple .dropbutton-action .ajax-progress {
+  position: relative !important;
+  top: -4px !important;
+  left: 30px !important;
+}

--- a/css/landing_page.css
+++ b/css/landing_page.css
@@ -39,7 +39,7 @@
   letter-spacing: normal;
 }
 
-.dropbutton-multiple .dropbutton-action .ajax-progress {
+div.dropbutton-multiple .dropbutton-action .ajax-progress {
   position: relative !important;
   top: -4px !important;
   left: 30px !important;


### PR DESCRIPTION
**Jira** : https://digital-engagement.atlassian.net/browse/SDPA-6056

Changes
1) Please wait ajax progress under Confirm Removal Dropdown css changes to prevent overlapping of "Confirm Removal" text and "Please wait..."

![image](https://user-images.githubusercontent.com/9244829/157611592-1cd33e3b-d35c-4272-ab86-8ca7c2e3ce7e.png)
