### PR TITLE
Feature/sdpa 6050 display two stat grid blocks

### DIFF
--- a/js/statistics_grid.js
+++ b/js/statistics_grid.js
@@ -1,0 +1,13 @@
+(function ($, Drupal) {
+
+  'use strict';
+
+  Drupal.behaviors.hideParagraphs = {
+    attach: function (context, settings) {
+      const statisticsGridBlockCount = $('.paragraph-type--statistics-grid').find('tr[class*=draggable]').length;
+      if(statisticsGridBlockCount) {
+        $('.paragraph-type--statistics-grid').find('span[class*=paragraphs-badge]').html(statisticsGridBlockCount);
+      }
+    }
+  };
+})(jQuery, Drupal);

--- a/js/statistics_grid.js
+++ b/js/statistics_grid.js
@@ -8,6 +8,14 @@
       if(statisticsGridBlockCount) {
         $('.paragraph-type--statistics-grid').find('span[class*=paragraphs-badge]').html(statisticsGridBlockCount);
       }
+
+      // Display a default of 2 statistics-grid blocks
+      if(statisticsGridBlockCount === 1) {
+        // Hide the first statistics-grid block while the second one loads
+        $('.paragraph-type--statistics-grid').find('tr[class*=draggable]').hide()
+        // Add another statistic grid block
+        $(context).find("input[id*=field-statistic-block-add-more-add-more-button-statistic-block]").click();
+      }
     }
   };
 })(jQuery, Drupal);

--- a/tide_landing_page.libraries.yml
+++ b/tide_landing_page.libraries.yml
@@ -4,5 +4,6 @@ landing_page_form:
       css/landing_page.css: {}
   js:
     js/hide_elements.js: {}
+    js/statistics_grid.js: {}
   dependencies:
     - core/jquery


### PR DESCRIPTION
**Jira** : https://digital-engagement.atlassian.net/browse/SDPA-6050

**Changes**
1) When a user adds a statistic grid then by default 2 stat grid blocks should display.

![image](https://user-images.githubusercontent.com/9244829/160388305-773138fe-b60b-4720-abaa-75c303c1419f.png)
