### PR TITLE
[SRM-403] Fix Stat Grid 2 default blocks not showing

### DIFF
--- a/tide_landing_page.install
+++ b/tide_landing_page.install
@@ -2431,10 +2431,10 @@ function tide_landing_page_update_8043() {
   $config_factory = \Drupal::configFactory();
   $config = $config_factory->getEditable('core.entity_form_display.paragraph.statistics_grid.default');
 
-  if (!$config->isNew() && !empty($config->get('content.field_statistic_block.settings.default_paragraph_type'))) {
+  if (!empty($config->get('content.field_statistic_block.settings.default_paragraph_type'))) {
     $config->set('content.field_statistic_block.settings.default_paragraph_type', 'statistic_block')->save();
   }
-  if (!$config->isNew() && !empty($config->get('content.field_statistic_block.settings.default_paragraph_count'))) {
+  if (!empty($config->get('content.field_statistic_block.settings.default_paragraph_count'))) {
     $config->set('content.field_statistic_block.settings.default_paragraph_count', '2')->save();
   }
 }


### PR DESCRIPTION
Jira: https://digital-engagement.atlassian.net/browse/SRM-403

Changed:
1) The "!$config->isNew()" for the config setting is preventing the config being set as contnent-vic and others already has the config.