### PR TITLE
Updated circle ci config.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,11 @@ workflows:
   main:
     jobs:
       - build
-      - build_suggest
+      - build_suggest:
+          filters:
+            branches:
+              ignore:
+                - reference
 
   mergetoreference:
     jobs:


### PR DESCRIPTION
### JIRA
https://digital-vic.atlassian.net/browse/SRM-526

### Changes
Ignoring build suggest to be run on reference branch in circle ci. As reference branch is a mirror copy of develop, it does not require the build suggest to run. If we want to run the build suggest it will require more maintenance work on the merge to reference script and it is not necessary to be tested against reference, so ignoring this should be fine.