### PR TITLE
[SDPAP-8094] Replacement of the deprecated function

### DIFF
--- a/tide_landing_page.module
+++ b/tide_landing_page.module
@@ -181,9 +181,9 @@ function tide_landing_page_form_node_form_alter(&$form, FormStateInterface $form
 }
 
 /**
- * Implements hook_field_widget_WIDGET_TYPE_form_alter().
+ * Implements hook_field_widget_single_element_WIDGET_TYPE_form_alter().
  */
-function tide_landing_page_field_widget_paragraphs_form_alter(&$element, FormStateInterface $form_state, $context) {
+function tide_landing_page_field_widget_single_element_paragraphs_form_alter(&$element, FormStateInterface $form_state, $context) {
   /** @var \Drupal\Core\Field\FieldItemListInterface $items */
   $items = $context['items'];
   $field_definition = $items->getFieldDefinition();


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SDPAP-8094

### Change
replaces `hook_field_widget_WIDGET_TYPE_form_alter` by `hook_field_widget_single_element_WIDGET_TYPE_form_alter`

### More details
https://www.drupal.org/node/3180429

> hook_field_widget_form_alter (hook_field_widget_WIDGET_TYPE_form_alter) was marked as deprecated and will be replaced by hook_field_widget_single_element_form_alter (hook_field_widget_single_element_WIDGET_TYPE_form_alter).

It seems that hook_field_widget_WIDGET_TYPE_form_alter is not functioning properly in Drupal 9.5.x due to the deprecation of functions.