### PR TITLE
[SRM-1237] Updated card enhancer to correctly access the date string value and pass it to the date converter.

### DIFF
--- a/src/Plugin/jsonapi/FieldEnhancer/CardLinkEnhancer.php
+++ b/src/Plugin/jsonapi/FieldEnhancer/CardLinkEnhancer.php
@@ -183,7 +183,7 @@ class CardLinkEnhancer extends ResourceFieldEnhancerBase {
       }
       // Add the date field for publication.
       if ($node->hasField('field_publication_date') && !$node->field_publication_date->isEmpty()) {
-        $card_fields['date'] = TideLandingPageHelper::localDateAndTimeFormatter($node->get('field_publication_date')->getValue()[0]);
+        $card_fields['date'] = TideLandingPageHelper::localDateAndTimeFormatter($node->get('field_publication_date')->getValue()[0]['value']);
       }
     }
     if ($module_handler->moduleExists('tide_profile')) {


### PR DESCRIPTION
### JIRA
https://digital-vic.atlassian.net/browse/SRM-1237

### Issue
The date field value accessing structure changed from `$node->get('field_publication_date')->getValue()[0]` to `$node->get('field_publication_date')->getValue()[0]['value']`, which causes throwing error for car enhancer when trying to send out api response for a page which has the publication page added in a card.

### Changes
Matched the structure to access the single value for the field as this is not a range and only has one value.
