### PR TITLE
[SDPAP-8672]remove news and event from search block

### DIFF
--- a/config/install/field.storage.paragraph.field_paragraph_search_block.yml
+++ b/config/install/field.storage.paragraph.field_paragraph_search_block.yml
@@ -14,12 +14,6 @@ settings:
       value: none
       label: 'Full site search'
     -
-      value: event
-      label: Events
-    -
-      value: news
-      label: News
-    -
       value: custom
       label: Custom
   allowed_values_function: ''

--- a/tide_landing_page.install
+++ b/tide_landing_page.install
@@ -5,7 +5,7 @@
  * Tide Landing Page install.
  */
 
- use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\tide_landing_page\TideLandingPageOperation;
 
 /**

--- a/tide_landing_page.install
+++ b/tide_landing_page.install
@@ -5,6 +5,7 @@
  * Tide Landing Page install.
  */
 
+ use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\tide_landing_page\TideLandingPageOperation;
 
 /**
@@ -36,4 +37,19 @@ function tide_landing_page_update_10100() {
   }
   $config->set('settings.allowed_values', $allowed_values);
   $config->save();
+}
+
+/**
+ * Remove event and news from search block.
+ */
+function tide_landing_page_update_10101() {
+  $field_storage = FieldStorageConfig::loadByName('paragraph', 'field_paragraph_search_block');
+  if (!$field_storage) {
+    return;
+  }
+  $current_allowed_values = $field_storage->getSetting('allowed_values');
+  unset($current_allowed_values['event']);
+  unset($current_allowed_values['news']);
+  $field_storage->setSetting('allowed_values', $current_allowed_values);
+  $field_storage->save();
 }


### PR DESCRIPTION
https://digital-vic.atlassian.net/browse/SDPAP-8672

Remove news and event values from search block

Testing link: https://nginx-php.pr-379.content-reference-sdp-vic-gov-au.sdp4.sdp.vic.gov.au/
<img width="912" alt="Screenshot 2024-02-22 at 5 03 47 pm" src="https://github.com/dpc-sdp/tide_landing_page/assets/47239456/e9a2b8e0-0b5f-4d3e-be19-a3191d2934e2">

